### PR TITLE
Add support for custom encodings

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,16 @@ cloudscraper.post('http://website.com/', {field1: 'value', field2: 2}, function(
 });
 ```
 
+A generic request can be made with `cloudscraper.request(options, callback)`. The options object should follow [request's options](https://www.npmjs.com/package/request#request-options-callback). Not everything is supported however, for example http methods other than GET and POST. If you wanted to request an image in binary data you could use the encoding option:
+
+```javascript
+cloudscraper.request({method: 'GET',
+                      url:'http://website.com/image',
+                      encoding: null,
+                      }, function(err, response, body) {
+                      //body is now a buffer object instead of a string
+});
+```
 
 ##Error object
 Error object has following structure:

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ var request      = require('request').defaults({jar: true}), // Cookies should b
  * Performs get request to url with headers.
  * @param  {String}    url
  * @param  {Function}  callback    function(error, response, body) {}
- * @param  {[Object}   headers     Hash with headers, e.g. {'Referer': 'http://google.com', 'User-Agent': '...'}
+ * @param  {Object}    headers     Hash with headers, e.g. {'Referer': 'http://google.com', 'User-Agent': '...'}
  */
 cloudscraper.get = function(url, callback, headers) {
   performRequest({
@@ -22,7 +22,7 @@ cloudscraper.get = function(url, callback, headers) {
  * @param  {String}        url
  * @param  {String|Object} body        Will be passed as form data
  * @param  {Function}      callback    function(error, response, body) {}
- * @param  {[Object}       headers     Hash with headers, e.g. {'Referer': 'http://google.com', 'User-Agent': '...'}
+ * @param  {Object}        headers     Hash with headers, e.g. {'Referer': 'http://google.com', 'User-Agent': '...'}
  */
 cloudscraper.post = function(url, body, callback, headers) {
   var data = '',
@@ -48,6 +48,11 @@ cloudscraper.post = function(url, body, callback, headers) {
   }, callback);
 }
 
+/**
+ * Performs get or post request with generic request options
+ * @Param {Object}   options   Object to be passed to request's options argument
+ * @Param {Function} callback  function(error, response, body) {}
+ */
 cloudscraper.request = function(options, callback) {
   performRequest(options, callback);
 }
@@ -58,6 +63,15 @@ function performRequest(options, callback) {
   options.headers = options.headers || {};
   makeRequest = requestMethod(options.method);
 
+  //Can't just do the normal options.encoding || 'utf8'
+  //because null is a valid encoding.
+  if('encoding' in options) {
+    options.realEncoding = options.encoding;
+  } else {
+    options.realEncoding = 'utf8';
+  }
+  options.encoding = null;
+  
   if (!options.url || !callback) {
     throw new Error('To perform request, define both url and callback');
   }
@@ -66,19 +80,20 @@ function performRequest(options, callback) {
 
   makeRequest(options, function(error, response, body) {
     var validationError;
+    var stringBody = body.toString('utf8');
 
-    if (validationError = checkForErrors(error, body)) {
+    if (validationError = checkForErrors(error, stringBody)) {
       return callback(validationError, body, response);
     }
 
     // If body contains specified string, solve challenge
-    if (body.indexOf('a = document.getElementById(\'jschl-answer\');') !== -1) {
+    if (stringBody.indexOf('a = document.getElementById(\'jschl-answer\');') !== -1) {
       setTimeout(function() {
-        return solveChallenge(response, body, options, callback);
+        return solveChallenge(response, stringBody, options, callback);
       }, Timeout);
     } else {
       // All is good
-      callback(error, response, body);
+      giveResults(options, error, response, body, callback);
     }
   });
 }
@@ -157,9 +172,11 @@ function solveChallenge(response, body, options, callback) {
                                       //by default, but for some reason it's not
       options.url = response.headers.location;
       delete options.qs;
-      makeRequest(options, callback);
+      makeRequest(options, function(error, response, body) {
+        giveResults(options, error, response, body, callback);
+      });
     } else {
-      callback(error, response, body);
+      giveResults(options, error, response, body, callback);
     }
   });
 }
@@ -170,6 +187,14 @@ function requestMethod(method) {
   method = method.toUpperCase();
 
   return method === 'POST' ? request.post : request.get;
+}
+
+function giveResults(options, error, response, body, callback) {
+  if(typeof options.realEncoding == 'string') {
+    callback(error, response, body.toString(options.realEncoding));
+  } else {
+    callback(error, response, body);
+  }
 }
 
 module.exports = cloudscraper;

--- a/index.js
+++ b/index.js
@@ -50,8 +50,8 @@ cloudscraper.post = function(url, body, callback, headers) {
 
 /**
  * Performs get or post request with generic request options
- * @Param {Object}   options   Object to be passed to request's options argument
- * @Param {Function} callback  function(error, response, body) {}
+ * @param {Object}   options   Object to be passed to request's options argument
+ * @param {Function} callback  function(error, response, body) {}
  */
 cloudscraper.request = function(options, callback) {
   performRequest(options, callback);
@@ -190,7 +190,7 @@ function requestMethod(method) {
 }
 
 function giveResults(options, error, response, body, callback) {
-  if(typeof options.realEncoding == 'string') {
+  if(typeof options.realEncoding === 'string') {
     callback(error, response, body.toString(options.realEncoding));
   } else {
     callback(error, response, body);

--- a/specs/tests/cloudscraper.js
+++ b/specs/tests/cloudscraper.js
@@ -33,8 +33,8 @@ describe('Cloudscraper', function() {
 
     // Stub first call, which request makes to page. It should return requested page
     sandbox.stub(requestDefault, 'get')
-           .withArgs({method: 'GET', url: url, headers: headers})
-           .callsArgWith(1, null, exprectedResponse, requestedPage);
+      .withArgs({method: 'GET', url: url, headers: headers, encoding: null, realEncoding: 'utf8'})
+      .callsArgWith(1, null, exprectedResponse, requestedPage);
 
     cloudscraper.get(url, function(error, response, body) {
       expect(error).to.be.null();
@@ -52,8 +52,8 @@ describe('Cloudscraper', function() {
 
     // Cloudflare is enabled for site. It returns a page with js challenge
     stubbed = sandbox.stub(requestDefault, 'get')
-                .withArgs({method: 'GET', url: url, headers: headers})
-                .callsArgWith(1, null, response, jsChallengePage);
+      .withArgs({method: 'GET', url: url, headers: headers, encoding: null, realEncoding: 'utf8'})
+      .callsArgWith(1, null, response, jsChallengePage);
 
     // Second call to request.get will have challenge solution
     // It should contain url, answer, headers with Referer
@@ -68,7 +68,9 @@ describe('Cloudscraper', function() {
       headers: {
         'User-Agent': 'Chrome',
         'Referer': 'http://example-site.dev/path/'
-      }
+      },
+      encoding: null,
+      realEncoding: 'utf8'
     })
     .callsArgWith(1, null, response, requestedPage);
 
@@ -93,8 +95,8 @@ describe('Cloudscraper', function() {
 
     // Stub first call, which request makes to page. It should return requested page
     sandbox.stub(requestDefault, 'post')
-           .withArgs({method: 'POST', url: url, headers: postHeaders, body: body})
-           .callsArgWith(1, null, exprectedResponse, requestedPage);
+      .withArgs({method: 'POST', url: url, headers: postHeaders, body: body, encoding: null, realEncoding: 'utf8'})
+      .callsArgWith(1, null, exprectedResponse, requestedPage);
 
     cloudscraper.post(url, body, function(error, response, body) {
       expect(error).to.be.null();
@@ -115,8 +117,8 @@ describe('Cloudscraper', function() {
 
     // Stub first call, which request makes to page. It should return requested page
     sandbox.stub(requestDefault, 'post')
-           .withArgs({method: 'POST', url: url, headers: postHeaders, body: encodedBody})
-           .callsArgWith(1, null, exprectedResponse, requestedPage);
+      .withArgs({method: 'POST', url: url, headers: postHeaders, body: encodedBody, encoding: null, realEncoding: 'utf8'})
+      .callsArgWith(1, null, exprectedResponse, requestedPage);
 
     cloudscraper.post(url, rawBody, function(error, response, body) {
       expect(error).to.be.null();
@@ -126,4 +128,26 @@ describe('Cloudscraper', function() {
     }, headers);
   });
 
+  it('should return raw data when encoding is null', function(done) {
+    var expectedResponse = { statusCode: 200 };
+    var requestedData = new Buffer('R0lGODlhDwAPAKECAAAAzMzM/////wAAACwAAAAADwAPAAACIISPeQHsrZ5ModrLlN48CXF8m2iQ3YmmKqVlRtW4MLwWACH+H09wdGltaXplZCBieSBVbGVhZCBTbWFydFNhdmVyIQAAOw==', 'base64');
+    
+    sandbox.stub(requestDefault, 'get')
+      .withArgs({method: 'GET', url: url, headers: headers, encoding: null, realEncoding: null})
+      .callsArgWith(1, null, expectedResponse, requestedData);
+
+    var options = {
+      method: 'GET',
+      url: url,
+      encoding: null,
+      headers: headers
+    };
+
+    cloudscraper.request(options, function(error, response, body) {
+      expect(error).to.be.null();
+      expect(response).to.be.equal(expectedResponse);
+      expect(body).to.be.equal(requestedData);
+      done();
+    });
+  });
 });

--- a/specs/tests/errors.js
+++ b/specs/tests/errors.js
@@ -35,8 +35,8 @@ describe('Cloudscraper', function() {
         fakeError = {fake: 'error'}; //not real request error, but it doesn't matter
 
     sandbox.stub(requestDefault, 'get')
-           .withArgs({method: 'GET', url: url, headers: headers})
-           .callsArgWith(1, fakeError, response, '');
+      .withArgs({method: 'GET', url: url, headers: headers, encoding: null, realEncoding: 'utf8'})
+      .callsArgWith(1, fakeError, response, '');
 
     cloudscraper.get(url, function(error) {
       expect(error).to.be.eql({errorType: 0, error: fakeError}); // errorType 0, means it is some kind of system error
@@ -49,8 +49,8 @@ describe('Cloudscraper', function() {
     var response = { statusCode: 503 };
 
     sandbox.stub(requestDefault, 'get')
-           .withArgs({method: 'GET', url: url, headers: headers})
-           .callsArgWith(1, null, response, captchaPage);
+      .withArgs({method: 'GET', url: url, headers: headers, encoding: null, realEncoding: 'utf8'})
+      .callsArgWith(1, null, response, captchaPage);
 
     cloudscraper.get(url, function(error, body) {
       expect(error).to.be.eql({errorType: 1}); // errorType 1, means captcha is served
@@ -64,8 +64,8 @@ describe('Cloudscraper', function() {
     var response = { statusCode: 500 };
 
     sandbox.stub(requestDefault, 'get')
-           .withArgs({method:'GET', url: url, headers: headers})
-           .callsArgWith(1, null, response, accessDenied);
+      .withArgs({method:'GET', url: url, headers: headers, encoding: null, realEncoding: 'utf8'})
+      .callsArgWith(1, null, response, accessDenied);
 
     cloudscraper.get(url, function(error, body) {
       expect(error).to.be.eql({errorType: 2, error: 1006}); // errorType 2, means inner cloudflare error
@@ -77,8 +77,8 @@ describe('Cloudscraper', function() {
   it('should return error if challenge page failed to be parsed', function(done) {
     var response = helper.fakeResponseObject(200, headers, invalidChallenge, url);
     sandbox.stub(requestDefault, 'get')
-           .withArgs({method: 'GET', url: url, headers: headers})
-           .callsArgWith(1, null, response, invalidChallenge);
+      .withArgs({method: 'GET', url: url, headers: headers, encoding: null, realEncoding: 'utf8'})
+      .callsArgWith(1, null, response, invalidChallenge);
 
     cloudscraper.get(url, function(error, body) {
       expect(error.errorType).to.be.eql(3); // errorType 3, means parsing failed


### PR DESCRIPTION
Currently everything gets encoded as utf8 strings, which causes problems for trying to load binary data such as images. This lets you pass in an encoding key in the options object of cloudscraper.request() that will determine how your data is encoded. (null for a buffer object is what I needed)