### PR TITLE
Fix for the case when using proxies

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
-var request      = require('request').defaults({jar: true}), // Cookies should be enabled
+var request = require('request').defaults({ jar: true }), // Cookies should be enabled
+    urlp = require('url'),
     UserAgent    = 'Ubuntu Chromium/34.0.1847.116 Chrome/34.0.1847.116 Safari/537.36',
     Timeout      = 6000, // Cloudflare requires a delay of 5 seconds, so wait for at least 6.
     cloudscraper = {};
@@ -130,11 +131,18 @@ function checkForErrors(error, body) {
 
 function solveChallenge(response, body, options, callback) {
   var challenge = body.match(/name="jschl_vc" value="(\w+)"/),
-      host = response.request.host,
+      host = null,
       makeRequest = requestMethod(options.method),
       jsChlVc,
       answerResponse,
       answerUrl;
+
+  var pr = urlp.parse(response.request.href);
+  if (pr != null && pr.hostname != null) {
+     host = pr.hostname;
+  } else {
+      host = response.request.host;
+  }
 
   if (!challenge) {
     return callback({errorType: 3, error: 'I cant extract challengeId (jschl_vc) from page'}, body, response);
@@ -160,7 +168,7 @@ function solveChallenge(response, body, options, callback) {
   try {
     answerResponse = {
       'jschl_vc': jsChlVc,
-      'jschl_answer': (eval(challenge) + response.request.host.length),
+      'jschl_answer': (eval(challenge) + host.length),
       'pass': challenge_pass
     };
   } catch (err) {


### PR DESCRIPTION
Hello,

I've used this module for bypassing the cloudflare protection which worked, however when I used it with proxy servers I got problems.

If you make a request with a proxy

> response.request.host

that will be the same as the proxy server's address instead of the target site's address so the solution is to parse

> response.request.href

and use the host part of it which will correctly contain the host name for both proxy and non-proxy usage.
