### PR TITLE
Promisify requests

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,10 +10,10 @@ var request      = requestModule.defaults({jar: jar}), // Cookies should be enab
 /**
  * Performs get request to url with headers.
  * @param  {String}    url
- * @param  {Function}  callback    function(error, response, body) {}
  * @param  {Object}    headers     Hash with headers, e.g. {'Referer': 'http://google.com', 'User-Agent': '...'}
+ * @param  {Function}  callback    function(error, response, body) {}
  */
-cloudscraper.get = function(url, callback, headers) {
+cloudscraper.get = function(url, headers, callback) {
   performRequest({
     method: 'GET',
     url: url,
@@ -25,10 +25,10 @@ cloudscraper.get = function(url, callback, headers) {
  * Performs post request to url with headers.
  * @param  {String}        url
  * @param  {String|Object} body        Will be passed as form data
- * @param  {Function}      callback    function(error, response, body) {}
  * @param  {Object}        headers     Hash with headers, e.g. {'Referer': 'http://google.com', 'User-Agent': '...'}
+ * @param  {Function}      callback    function(error, response, body) {}
  */
-cloudscraper.post = function(url, body, callback, headers) {
+cloudscraper.post = function(url, body, headers, callback) {
   var data = '',
       bodyType = Object.prototype.toString.call(body);
 


### PR DESCRIPTION
I've added Promise support for this library(for `get`, `post` and `request` functions.

Here it what I've used to test it:

```
var cloudscraper = require('cloudscraper');
var url =  <some URL to test here>

try {
  cloudscraper.get(url, null, function(error, response, body) {
    if (error) {
      console.log(`Error in GET function with callback result: ${e}`)
    } else {
      console.log(`GET function with result okay, body length: ${body.length}`)
    }
  });
} catch (e) {
  console.log(`Error in GET function with callback: ${e}`)
}

try {
  cloudscraper.get(url, null)
    .then(result => {
      console.log(`GET function without result okay, body length: ${result.body.length}`)
    })
    .catch(err => console.log(`Error: ${err}`))
} catch (e) {
  console.log(`Error in GET function without callback: ${e}`)
}

```

Now it can be called both ways (either providing callback or not). If callback is provided, the function is called. If not, the Promise is returned.

Unfortunately I had to switch the arguments (for `callback` to be the last one, so user can omit it without omitting the other arguments). See the first comment for this.

And also, since function can't return more than 1 value, the value returned with the Promise callback is an object, where `response` is the response and `body` is a body.

I'm not sure if it's the best way it can be done, so check this out and please tell me if everything is okay or there's some things that can be improved.