### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ cloudscraper.request({method: 'GET',
 });
 ```
 
-##Error object
+## Error object
 Error object has following structure:
 ```
 var error = {errorType: 0, error:...};


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
