### PR TITLE
Add promise support for get, post, and request

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,6 +14,12 @@ var request      = requestModule.defaults({jar: jar}), // Cookies should be enab
  * @param  {Function}  callback    function(error, response, body) {}
  */
 cloudscraper.get = function(url, headers, callback) {
+  if (typeof headers === 'function') { // backward compatibility with get(url, callback)
+    var temp;
+    temp = headers;
+    headers = callback;
+    callback = temp;
+  }
   performRequest({
     method: 'GET',
     url: url,
@@ -29,6 +35,12 @@ cloudscraper.get = function(url, headers, callback) {
  * @param  {Function}      callback    function(error, response, body) {}
  */
 cloudscraper.post = function(url, body, headers, callback) {
+  if (typeof headers === 'function') { // backward compatibility with post(url, body, callback)
+    var temp;
+    temp = headers;
+    headers = callback;
+    callback = temp;
+  }
   var data = '',
       bodyType = Object.prototype.toString.call(body);
 

--- a/index.js
+++ b/index.js
@@ -11,24 +11,14 @@ var request      = requestModule.defaults({jar: jar}), // Cookies should be enab
  * Performs get request to url with headers.
  * @param  {String}    url
  * @param  {Object}    headers     Hash with headers, e.g. {'Referer': 'http://google.com', 'User-Agent': '...'}
- * @param  {Function}  callback    function(error, response, body) {}. If omitted, a Promise will be returned.
+ * @param  {Function}  callback    function(error, response, body) {}
  */
 cloudscraper.get = function(url, headers, callback) {
-  if (callback === undefined) { /* no callback specified, returning Promise */
-    return new Promise(function (resolve, reject) {
-      performRequest({
-        method: 'GET',
-        url: url,
-        headers: headers
-      }, true, { resolve: resolve, reject: reject });
-    })
-  } else { /* callback specified */
-    performRequest({
-      method: 'GET',
-      url: url,
-      headers: headers
-    }, false, callback);
-  }
+  performRequest({
+    method: 'GET',
+    url: url,
+    headers: headers
+  }, callback);
 };
 
 /**
@@ -36,7 +26,7 @@ cloudscraper.get = function(url, headers, callback) {
  * @param  {String}        url
  * @param  {String|Object} body        Will be passed as form data
  * @param  {Object}        headers     Hash with headers, e.g. {'Referer': 'http://google.com', 'User-Agent': '...'}
- * @param  {Function}      callback    function(error, response, body) {}. If omitted, a Promise will be returned.
+ * @param  {Function}      callback    function(error, response, body) {}
  */
 cloudscraper.post = function(url, body, headers, callback) {
   var data = '',
@@ -54,44 +44,24 @@ cloudscraper.post = function(url, body, headers, callback) {
   headers['Content-Type'] = headers['Content-Type'] || 'application/x-www-form-urlencoded; charset=UTF-8';
   headers['Content-Length'] = headers['Content-Length'] || data.length;
 
-  if (callback === undefined) {
-    return new Promise(function(resolve, reject) {
-      performRequest({
-        method: 'POST',
-        body: data,
-        url: url,
-        headers: headers
-      }, true, { resolve: resolve, reject: reject });
-    })
-  } else {
-    performRequest({
-      method: 'POST',
-      body: data,
-      url: url,
-      headers: headers
-    }, false, callback);
-  }
+  performRequest({
+    method: 'POST',
+    body: data,
+    url: url,
+    headers: headers
+  }, callback);
 }
 
 /**
  * Performs get or post request with generic request options
  * @param {Object}   options   Object to be passed to request's options argument
- * @param {Function} callback  function(error, response, body) {}. If omitted, a Promise will be returned.
+ * @param {Function} callback  function(error, response, body) {}
  */
 cloudscraper.request = function(options, callback) {
-  if (callback === undefined) {
-    return new Promise(function (resolve, reject) {
-      performRequest(options, true, { resolve: resolve, reject: reject });
-    })
-  } else {
-    performRequest(options, false, callback);
-  }
+  performRequest(options, callback);
 }
 
-// The promisable variable is boolean.
-// If promisable === true, then the callback is an object and contains resolve and reject callbacks.
-// If promisable === false, then the callback is a function.
-function performRequest(options, promisable, callback) {
+function performRequest(options, callback) {
   var method;
   options = options || {};
   options.headers = options.headers || {};
@@ -106,8 +76,8 @@ function performRequest(options, promisable, callback) {
   }
   options.encoding = null;
 
-  if (!options.url) {
-    throw new Error('To perform request, define url.');
+  if (!options.url || !callback) {
+    throw new Error('To perform request, define both url and callback');
   }
 
   options.headers['User-Agent'] = options.headers['User-Agent'] || UserAgent;
@@ -117,34 +87,26 @@ function performRequest(options, promisable, callback) {
     var stringBody;
 
     if (error || !body || !body.toString) {
-      if (promisable) {
-        return callback.reject({ errorType: 0, error: error });
-      } else {
-        return callback({ errorType: 0, error: error }, body, response);
-      }
+      return callback({ errorType: 0, error: error }, body, response);
     }
 
     stringBody = body.toString('utf8');
 
     if (validationError = checkForErrors(error, stringBody)) {
-      if (promisable) {
-        return callback.reject(validationError);
-      } else {
-        return callback(validationError, body, response);
-      }
+      return callback(validationError, body, response);
     }
 
     // If body contains specified string, solve challenge
     if (stringBody.indexOf('a = document.getElementById(\'jschl-answer\');') !== -1) {
       setTimeout(function() {
-        return solveChallenge(response, stringBody, options, promisable, callback);
+        return solveChallenge(response, stringBody, options, callback);
       }, Timeout);
     } else if (stringBody.indexOf('You are being redirected') !== -1 ||
                stringBody.indexOf('sucuri_cloudproxy_js') !== -1) {
-      setCookieAndReload(response, stringBody, options, promisable, callback);
+      setCookieAndReload(response, stringBody, options, callback);
     } else {
       // All is good
-      giveResults(options, error, response, body, promisable, callback);
+      giveResults(options, error, response, body, callback);
     }
   });
 }
@@ -173,7 +135,7 @@ function checkForErrors(error, body) {
 }
 
 
-function solveChallenge(response, body, options, promisable, callback) {
+function solveChallenge(response, body, options, callback) {
   var challenge = body.match(/name="jschl_vc" value="(\w+)"/),
       host = response.request.host,
       makeRequest = requestMethod(options.method),
@@ -182,11 +144,7 @@ function solveChallenge(response, body, options, promisable, callback) {
       answerUrl;
 
   if (!challenge) {
-    if (promisable) {
-      return callback.reject({errorType: 3, error: 'I cant extract challengeId (jschl_vc) from page'});
-    } else {
-      return callback({errorType: 3, error: 'I cant extract challengeId (jschl_vc) from page'}, body, response);
-    }
+    return callback({errorType: 3, error: 'I cant extract challengeId (jschl_vc) from page'}, body, response);
   }
 
   jsChlVc = challenge[1];
@@ -194,12 +152,7 @@ function solveChallenge(response, body, options, promisable, callback) {
   challenge = body.match(/getElementById\('cf-content'\)[\s\S]+?setTimeout.+?\r?\n([\s\S]+?a\.value =.+?)\r?\n/i);
 
   if (!challenge) {
-    if (promisable) {
-      return callback.reject({errorType: 3, error: 'I cant extract method from setTimeOut wrapper'});
-    } else {
-      return callback({errorType: 3, error: 'I cant extract method from setTimeOut wrapper'}, body, response);
-    }
-
+    return callback({errorType: 3, error: 'I cant extract method from setTimeOut wrapper'}, body, response);
   }
 
   challenge_pass = body.match(/name="pass" value="(.+?)"/)[1];
@@ -218,11 +171,7 @@ function solveChallenge(response, body, options, promisable, callback) {
       'pass': challenge_pass
     };
   } catch (err) {
-    if (promisable) {
-      return callback.reject({errorType: 3, error: 'Error occurred during evaluation: ' +  err.message});
-    } else {
-      return callback({errorType: 3, error: 'Error occurred during evaluation: ' +  err.message}, body, response);
-    }
+    return callback({errorType: 3, error: 'Error occurred during evaluation: ' +  err.message}, body, response);
   }
 
   answerUrl = response.request.uri.protocol + '//' + host + '/cdn-cgi/l/chk_jschl';
@@ -234,11 +183,7 @@ function solveChallenge(response, body, options, promisable, callback) {
   // Make request with answer
   makeRequest(options, function(error, response, body) {
     if(error) {
-      if (promisable) {
-        return callback.reject({ errorType: 0, error: error });
-      } else {
-        return callback({ errorType: 0, error: error }, response, body);
-      }
+      return callback({ errorType: 0, error: error }, response, body);
     }
 
     if(response.statusCode === 302) { //occurrs when posting. request is supposed to auto-follow these
@@ -246,24 +191,20 @@ function solveChallenge(response, body, options, promisable, callback) {
       options.url = response.headers.location;
       delete options.qs;
       makeRequest(options, function(error, response, body) {
-        giveResults(options, error, response, body, promisable, callback);
+        giveResults(options, error, response, body, callback);
       });
     } else {
-      giveResults(options, error, response, body, promisable, callback);
+      giveResults(options, error, response, body, callback);
     }
   });
 }
 
-function setCookieAndReload(response, body, options, promisable, callback) {
+function setCookieAndReload(response, body, options, callback) {
   var challenge = body.match(/S='([^']+)'/);
   var makeRequest = requestMethod(options.method);
 
   if (!challenge) {
-    if (promisable) {
-      return callback.reject({errorType: 3, error: 'I cant extract cookie generation code from page'});
-    } else {
-      return callback({errorType: 3, error: 'I cant extract cookie generation code from page'}, body, response);
-    }
+    return callback({errorType: 3, error: 'I cant extract cookie generation code from page'}, body, response);
   }
 
   var base64EncodedCode = challenge[1];
@@ -284,13 +225,9 @@ function setCookieAndReload(response, body, options, promisable, callback) {
 
   makeRequest(options, function(error, response, body) {
     if(error) {
-      if (promisable) {
-        return callback.reject({ errorType: 0, error: error });
-      } else {
-        return callback({ errorType: 0, error: error }, response, body);
-      }
+      return callback({ errorType: 0, error: error }, response, body);
     }
-    giveResults(options, error, response, body, promisable, callback);
+    giveResults(options, error, response, body, callback);
   });
 }
 
@@ -302,12 +239,9 @@ function requestMethod(method) {
   return method === 'POST' ? request.post : request.get;
 }
 
-function giveResults(options, error, response, body, promisable, callback) {
+function giveResults(options, error, response, body, callback) {
   if(typeof options.realEncoding === 'string') {
-    body = body.toString(options.realEncoding)
-  }
-  if (promisable) {
-    callback.resolve({ response: response, body: body })
+    callback(error, response, body.toString(options.realEncoding));
   } else {
     callback(error, response, body);
   }

--- a/index.js
+++ b/index.js
@@ -10,10 +10,10 @@ var request      = requestModule.defaults({jar: jar}), // Cookies should be enab
 /**
  * Performs get request to url with headers.
  * @param  {String}    url
- * @param  {Function}  callback    function(error, response, body) {}
  * @param  {Object}    headers     Hash with headers, e.g. {'Referer': 'http://google.com', 'User-Agent': '...'}
+ * @param  {Function}  callback    function(error, response, body) {}
  */
-cloudscraper.get = function(url, callback, headers) {
+cloudscraper.get = function(url, headers, callback) {
   performRequest({
     method: 'GET',
     url: url,
@@ -25,10 +25,10 @@ cloudscraper.get = function(url, callback, headers) {
  * Performs post request to url with headers.
  * @param  {String}        url
  * @param  {String|Object} body        Will be passed as form data
- * @param  {Function}      callback    function(error, response, body) {}
  * @param  {Object}        headers     Hash with headers, e.g. {'Referer': 'http://google.com', 'User-Agent': '...'}
+ * @param  {Function}      callback    function(error, response, body) {}
  */
-cloudscraper.post = function(url, body, callback, headers) {
+cloudscraper.post = function(url, body, headers, callback) {
   var data = '',
       bodyType = Object.prototype.toString.call(body);
 

--- a/specs/tests/cloudscraper.js
+++ b/specs/tests/cloudscraper.js
@@ -236,4 +236,60 @@ describe('Cloudscraper', function() {
       done();
     }, headers);
   });
+  
+  it('should return promise correctly on get without callback', function(done) {
+    var expectedResponse = { statusCode: 200 };
+
+    // Stub first call, which request makes to page. It should return requested page
+    sandbox.stub(requestDefault, 'get')
+      .withArgs({method: 'GET', url: url, headers: headers, encoding: null, realEncoding: 'utf8'})
+      .callsArgWith(1, null, expectedResponse, requestedPage);
+
+    cloudscraper.get(url, headers).then( function(resolve) {
+      expect(resolve.body).to.be.equal(requestedPage);
+      expect(resolve.response).to.be.equal(expectedResponse);
+      done();
+    });
+  });
+  
+  it('should return promise correctly on post without callback', function(done) {
+    var expectedResponse = { statusCode: 200 },
+        body = 'form-data-body',
+        postHeaders = headers;
+
+    postHeaders['Content-Type'] = 'application/x-www-form-urlencoded; charset=UTF-8';
+    postHeaders['Content-Length'] = body.length;
+
+
+    // Stub first call, which request makes to page. It should return requested page
+    sandbox.stub(requestDefault, 'post')
+      .withArgs({method: 'POST', url: url, headers: postHeaders, body: body, encoding: null, realEncoding: 'utf8'})
+      .callsArgWith(1, null, expectedResponse, requestedPage);
+
+    cloudscraper.post(url, body, headers).then( function(resolve) {
+      expect(resolve.body).to.be.equal(requestedPage);
+      expect(resolve.response).to.be.equal(expectedResponse);
+      done();
+    });
+  });
+  
+  it('should return promise correctly on request without callback', function(done) {
+    var expectedResponse = { statusCode: 200 };
+
+    // Stub first call, which request makes to page. It should return requested page
+    sandbox.stub(requestDefault, 'get')
+      .withArgs({method: 'GET', url: url, headers: headers, encoding: null, realEncoding: 'utf8'})
+      .callsArgWith(1, null, expectedResponse, requestedPage);
+
+    cloudscraper.request({
+        method: 'GET',
+        url: url,
+        headers: headers
+    }).then( function(resolve) {
+      expect(resolve.body).to.be.equal(requestedPage);
+      expect(resolve.response).to.be.equal(expectedResponse);
+      done();
+    });
+  });
+  
 });

--- a/specs/tests/errors.js
+++ b/specs/tests/errors.js
@@ -127,5 +127,20 @@ describe('Cloudscraper', function() {
     this.clock.tick(7000); // tick the timeout
 
   });
+  
+  it('should return error if it was thrown by request on promise call', function(done) {
+    var response = { statusCode: 500 },
+        fakeError = {fake: 'error'}; //not real request error, but it doesn't matter
+
+    sandbox.stub(requestDefault, 'get')
+      .withArgs({method: 'GET', url: url, headers: headers, encoding: null, realEncoding: 'utf8'})
+      .callsArgWith(1, fakeError, response, '');
+
+    cloudscraper.get(url, headers).then().catch( function(error) {
+      expect(error).to.be.eql({errorType: 0, error: fakeError}); // errorType 0, means it is some kind of system error
+      done();
+    });
+
+  });
 
 });


### PR DESCRIPTION
Today, I reviewed @serge1peshcoff's #30 that add promise support to the existed functions, but his modified code does not work well with the callback methods because of the change in arguments ordering.

Hence, I forked this repo and modified some codes in get, post, and request functions to accept a promise call. The approach is different to @serge1peshcoff as I modified only the entry functions, and I left the private function almost untouched. I also added tests for the promise calling.

With these modification, there are some changes:

1. `.get(url, headers)`, `.post(url, body, headers)` should return a promise unless the last argument is replaced by a function.
2. `.get(url)`, `.post(url, body)` should return a promise.
3. `.request(options)` should return a promise.
4. `.get(url, callback)`, `.post(url, body, callback)`, `.request(options, callback)` should work correctly.
5. The resolved promise should return an object with keys: `response `and `body`, which is different from callback function.
6. The rejected promise should be catchable.

Thank you.