### PR TITLE
Multiple challenges should be properly handled

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Current cloudflare implementation requires browser to respect the timeout of 5 s
  - [roflmuffin](https://github.com/roflmuffin)
  - [Colecf](https://github.com/Colecf)
  - [Jeongbong Seo](https://github.com/jngbng)
+ - [Kamikadze4GAME](https://github.com/Kamikadze4GAME)
 
 ## Dependencies
 * request@2.49.0 https://github.com/request/request

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cloudscraper",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "description": "Bypasses cloudflare's anti-ddos page",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "devDependencies": {
     "chai": "^1.10.0",
     "grunt": "^0.4.5",
+    "grunt-cli": "^1.2.0",
     "grunt-mocha-test": "^0.12.4",
     "mocha": "^2.0.1",
     "sinon": "^1.12.1"


### PR DESCRIPTION
After solving a challenge, cloudflare might return a captcha page. Support this case and parse response for errors as well. Fixes https://github.com/codemanki/cloudscraper/issues/52 and https://github.com/codemanki/cloudscraper/pull/11