### PR TITLE
Support recursive challenge solving

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+## Change Log
+
+### v2.0.0 (09/12/2018)
+- [#2943](https://github.com/codemanki/cloudscraper/pull/66) Support recursive challenge solving. 
+- **BREAKING CHANGE** Before this, when any error has been detected, the callback was called with an incorrect order: `callback(.., body, response);` instead of `return callback(..., response, body);`

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Current cloudflare implementation requires browser to respect the timeout of 5 s
  - [x] Support page with simple redirects
  - [x] Add proper testing
  - [x] Remove manual 302 processing, replace with `followAllRedirects` param
+ - [ ] Parse out the timeout from chalenge page
  - [ ] Reoder the arguments in get/post/request methods and allow custom options to be passed in
  - [ ] Expose solve methods to use them independently
  - [ ] Support recaptcha solving
@@ -109,5 +110,5 @@ Current cloudflare implementation requires browser to respect the timeout of 5 s
  - [Kamikadze4GAME](https://github.com/Kamikadze4GAME)
 
 ## Dependencies
-* request@2.49.0 https://github.com/request/request
+* request https://github.com/request/request
 

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Current cloudflare implementation requires browser to respect the timeout of 5 s
  - [x] Support page with simple redirects
  - [x] Add proper testing
  - [x] Remove manual 302 processing, replace with `followAllRedirects` param
+ - [ ] Reoder the arguments in get/post/request methods and allow custom options to be passed in
  - [ ] Expose solve methods to use them independently
  - [ ] Support recaptcha solving
  - [ ] Promisification

--- a/README.md
+++ b/README.md
@@ -94,7 +94,8 @@ Current cloudflare implementation requires browser to respect the timeout of 5 s
  - [ ] Support cookies, so challenge can be solved once per session
  - [x] Support page with simple redirects
  - [x] Add proper testing
- - [ ] Remove manual 302 processing, replace with `followAllRedirects` param
+ - [x] Remove manual 302 processing, replace with `followAllRedirects` param
+ - [ ] Set a limit of recursive calls, to prevent many requests to be done
  - [ ] Parse out the timeout from chalenge page
  - [ ] Support recaptcha solving
  - [ ] Promisification

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ A generic request can be made with `cloudscraper.request(options, callback)`. Th
 cloudscraper.request({method: 'GET',
                       url:'http://website.com/image',
                       encoding: null,
+                      followAllRedirects: true, // mandatory for successful challenge solution
                       }, function(err, response, body) {
                       //body is now a buffer object instead of a string
 });

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ A generic request can be made with `cloudscraper.request(options, callback)`. Th
 cloudscraper.request({method: 'GET',
                       url:'http://website.com/image',
                       encoding: null,
+                      challengesToSolve: 3, // optional, if CF returns challenge after challenge, how many to solve before failing
                       followAllRedirects: true, // mandatory for successful challenge solution
                       }, function(err, response, body) {
                       //body is now a buffer object instead of a string
@@ -73,6 +74,7 @@ Where `errorType` can be following:
  - `1` cloudflare returned captcha. Nothing to do here. Bad luck
  - `2` cloudflare returned page with some inner error. `error` will be `Number` within this range `1012, 1011, 1002, 1000, 1004, 1010, 1006, 1007, 1008`. See more [here](https://support.cloudflare.com/hc/en-us/sections/200038216-CloudFlare-Error-Messages)
  - `3` this error is returned when library failed to parse and solve js challenge. `error` will be `String` with some details. :warning: :warning: __Most likely it means that cloudflare have changed their js challenge.__
+ - `4` CF went into a loop and started to return challenge after challenge. If number of solved challenges is greater than `3` and another challenge is returned, throw an error
 
 
 Running tests
@@ -95,8 +97,7 @@ Current cloudflare implementation requires browser to respect the timeout of 5 s
  - [x] Support page with simple redirects
  - [x] Add proper testing
  - [x] Remove manual 302 processing, replace with `followAllRedirects` param
- - [ ] Set a limit of recursive calls, to prevent many requests to be done
- - [ ] Parse out the timeout from chalenge page
+ - [ ] Expose solve methods to use them independently
  - [ ] Support recaptcha solving
  - [ ] Promisification
 

--- a/README.md
+++ b/README.md
@@ -93,6 +93,10 @@ Current cloudflare implementation requires browser to respect the timeout of 5 s
  - [ ] Support cookies, so challenge can be solved once per session
  - [x] Support page with simple redirects
  - [x] Add proper testing
+ - [ ] Remove manual 302 processing, replace with `followAllRedirects` param
+ - [ ] Parse out the timeout from chalenge page
+ - [ ] Support recaptcha solving
+ - [ ] Promisification
 
 ## Kudos to contributors
  - [roflmuffin](https://github.com/roflmuffin)

--- a/index.js
+++ b/index.js
@@ -117,9 +117,10 @@ function processRequestResponse(options, requestResult, callback) {
   isRedirectChallengePresent = stringBody.indexOf('You are being redirected') !== -1 || stringBody.indexOf('sucuri_cloudproxy_js') !== -1;
   isTargetPage = !isChallengePresent && !isRedirectChallengePresent;
 
-  if(!isTargetPage && options.challengesToSolve == 0) {
+  if(isChallengePresent && options.challengesToSolve == 0) {
     return callback({ errorType: 4 }, response, body);
   }
+
   // If body contains specified string, solve challenge
   if (isChallengePresent) {
     setTimeout(function() {

--- a/index.js
+++ b/index.js
@@ -87,7 +87,7 @@ function performRequest(options, callback) {
   options.headers['User-Agent'] = options.headers['User-Agent'] || UserAgent;
   options.challengesToSolve = options.challengesToSolve || MaxChallengesToSolve; // Might not be the best way how to pass this variable
   options.followAllRedirects = options.followAllRedirects === undefined ? true : options.followAllRedirects;
-  
+
   makeRequest(options, function(error, response, body) {
     processRequestResponse(options, {error: error, response: response, body: body}, callback);
   });
@@ -120,7 +120,6 @@ function processRequestResponse(options, requestResult, callback) {
   if(!isTargetPage && options.challengesToSolve == 0) {
     return callback({ errorType: 4 }, response, body);
   }
-
   // If body contains specified string, solve challenge
   if (isChallengePresent) {
     setTimeout(function() {

--- a/index.js
+++ b/index.js
@@ -191,17 +191,7 @@ function solveChallenge(response, body, options, callback) {
     if(error) {
       return callback({ errorType: 0, error: error }, response, body);
     }
-     // processResponseBody(options, error, response, body, callback);
-      if(response.statusCode === 302) { //occurrs when posting. request is supposed to auto-follow these
-                                        //by default, but for some reason it's not
-        options.url = response.headers.location;
-        delete options.qs;
-        makeRequest(options, function(error, response, body) {
-          processResponseBody(options, error, response, body, callback);
-        });
-      } else {
-        processResponseBody(options, error, response, body, callback);
-      }
+    processResponseBody(options, error, response, body, callback);
   });
 }
 

--- a/index.js
+++ b/index.js
@@ -2,10 +2,10 @@ var vm = require('vm');
 var requestModule = require('request');
 var jar = requestModule.jar();
 
-var request      = requestModule.defaults({jar: jar}), // Cookies should be enabled
-    UserAgent    = 'Ubuntu Chromium/34.0.1847.116 Chrome/34.0.1847.116 Safari/537.36',
-    Timeout      = 6000, // Cloudflare requires a delay of 5 seconds, so wait for at least 6.
-    cloudscraper = {};
+var request      = requestModule.defaults({jar: jar}); // Cookies should be enabled
+var UserAgent    = 'Ubuntu Chromium/34.0.1847.116 Chrome/34.0.1847.116 Safari/537.36';
+var Timeout      = 6000; // Cloudflare requires a delay of 5 seconds, so wait for at least 6.
+var cloudscraper = {};
 
 /**
  * Performs get request to url with headers.
@@ -30,8 +30,8 @@ cloudscraper.get = function(url, callback, headers) {
  * @param  {Object}        headers     Hash with headers, e.g. {'Referer': 'http://google.com', 'User-Agent': '...'}
  */
 cloudscraper.post = function(url, body, callback, headers) {
-  var data = '',
-      bodyType = Object.prototype.toString.call(body);
+  var data = '';
+  var bodyType = Object.prototype.toString.call(body);
 
   if(bodyType === '[object String]') {
     data = body;
@@ -141,12 +141,12 @@ function checkForErrors(error, body) {
 
 
 function solveChallenge(response, body, options, callback) {
-  var challenge = body.match(/name="jschl_vc" value="(\w+)"/),
-      host = response.request.host,
-      makeRequest = requestMethod(options.method),
-      jsChlVc,
-      answerResponse,
-      answerUrl;
+  var challenge = body.match(/name="jschl_vc" value="(\w+)"/);
+  var host = response.request.host;
+  var makeRequest = requestMethod(options.method);
+  var jsChlVc;
+  var answerResponse;
+  var answerUrl;
 
   if (!challenge) {
     return callback({errorType: 3, error: 'I cant extract challengeId (jschl_vc) from page'}, body, response);
@@ -191,6 +191,7 @@ function solveChallenge(response, body, options, callback) {
     if(error) {
       return callback({ errorType: 0, error: error }, response, body);
     }
+
     processResponseBody(options, error, response, body, callback);
   });
 }
@@ -212,7 +213,9 @@ function setCookieAndReload(response, body, options, callback) {
     },
     document: {}
   };
+
   vm.runInNewContext(cookieSettingCode, sandbox);
+
   try {
     jar.setCookie(sandbox.document.cookie, response.request.uri.href, {ignoreError: true});
   } catch (err) {

--- a/index.js
+++ b/index.js
@@ -17,7 +17,8 @@ cloudscraper.get = function(url, callback, headers) {
   performRequest({
     method: 'GET',
     url: url,
-    headers: headers
+    headers: headers,
+    followAllRedirects: true
   }, callback);
 };
 
@@ -48,7 +49,8 @@ cloudscraper.post = function(url, body, callback, headers) {
     method: 'POST',
     body: data,
     url: url,
-    headers: headers
+    headers: headers,
+    followAllRedirects: true
   }, callback);
 }
 
@@ -62,7 +64,6 @@ cloudscraper.request = function(options, callback) {
 }
 
 function performRequest(options, callback) {
-  var method;
   options = options || {};
   options.headers = options.headers || {};
 
@@ -103,7 +104,7 @@ function performRequest(options, callback) {
     // If body contains specified string, solve challenge
     if (stringBody.indexOf('a = document.getElementById(\'jschl-answer\');') !== -1) {
       setTimeout(function() {
-        return solveChallenge(response, stringBody, options, callback);
+        solveChallenge(response, stringBody, options, callback);
       }, Timeout);
     } else if (stringBody.indexOf('You are being redirected') !== -1 ||
                stringBody.indexOf('sucuri_cloudproxy_js') !== -1) {
@@ -190,17 +191,17 @@ function solveChallenge(response, body, options, callback) {
     if(error) {
       return callback({ errorType: 0, error: error }, response, body);
     }
-
-    if(response.statusCode === 302) { //occurrs when posting. request is supposed to auto-follow these
-                                      //by default, but for some reason it's not
-      options.url = response.headers.location;
-      delete options.qs;
-      makeRequest(options, function(error, response, body) {
+     // processResponseBody(options, error, response, body, callback);
+      if(response.statusCode === 302) { //occurrs when posting. request is supposed to auto-follow these
+                                        //by default, but for some reason it's not
+        options.url = response.headers.location;
+        delete options.qs;
+        makeRequest(options, function(error, response, body) {
+          processResponseBody(options, error, response, body, callback);
+        });
+      } else {
         processResponseBody(options, error, response, body, callback);
-      });
-    } else {
-      processResponseBody(options, error, response, body, callback);
-    }
+      }
   });
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cloudscraper",
-  "version": "1.5.1",
+  "version": "2.0.0",
   "description": "Bypasses cloudflare's anti-ddos page",
   "main": "index.js",
   "scripts": {

--- a/specs/fixtures/js_challenge_03_12_2018_1.html
+++ b/specs/fixtures/js_challenge_03_12_2018_1.html
@@ -1,0 +1,84 @@
+<!DOCTYPE HTML>
+<html lang="en-US">
+<head>
+  <meta charset="UTF-8" />
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=Edge,chrome=1" />
+  <meta name="robots" content="noindex, nofollow" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
+  <title>Just a moment...</title>
+  <style type="text/css">
+    html, body {width: 100%; height: 100%; margin: 0; padding: 0;}
+    body {background-color: #ffffff; font-family: Helvetica, Arial, sans-serif; font-size: 100%;}
+    h1 {font-size: 1.5em; color: #404040; text-align: center;}
+    p {font-size: 1em; color: #404040; text-align: center; margin: 10px 0 0 0;}
+    #spinner {margin: 0 auto 30px auto; display: block;}
+    .attribution {margin-top: 20px;}
+    @-webkit-keyframes bubbles { 33%: { -webkit-transform: translateY(10px); transform: translateY(10px); } 66% { -webkit-transform: translateY(-10px); transform: translateY(-10px); } 100% { -webkit-transform: translateY(0); transform: translateY(0); } }
+    @keyframes bubbles { 33%: { -webkit-transform: translateY(10px); transform: translateY(10px); } 66% { -webkit-transform: translateY(-10px); transform: translateY(-10px); } 100% { -webkit-transform: translateY(0); transform: translateY(0); } }
+    .bubbles { background-color: #404040; width:15px; height: 15px; margin:2px; border-radius:100%; -webkit-animation:bubbles 0.6s 0.07s infinite ease-in-out; animation:bubbles 0.6s 0.07s infinite ease-in-out; -webkit-animation-fill-mode:both; animation-fill-mode:both; display:inline-block; }
+  </style>
+
+    <script type="text/javascript">
+  //<![CDATA[
+  (function(){
+    var a = function() {try{return !!window.addEventListener} catch(e) {return !1} },
+    b = function(b, c) {a() ? document.addEventListener("DOMContentLoaded", b, c) : document.attachEvent("onreadystatechange", b)};
+    b(function(){
+      var a = document.getElementById('cf-content');a.style.display = 'block';
+      setTimeout(function(){
+        var s,t,o,p,b,r,e,a,k,i,n,g,f, zoqqEUY={"xzWMiyQ":+((!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+[])+(!+[]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(+[])+(!+[]+!![]+!![]+!![])+(+!![])+(!+[]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![])+(+!![]))/+((!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+[])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![])+(!+[]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![]))};
+        t = document.createElement('div');
+        t.innerHTML="<a href='/'>x</a>";
+        t = t.firstChild.href;r = t.match(/https?:\/\//)[0];
+        t = t.substr(r.length); t = t.substr(0,t.length-1);
+        a = document.getElementById('jschl-answer');
+        f = document.getElementById('challenge-form');
+        ;zoqqEUY.xzWMiyQ-=+((!+[]+!![]+!![]+!![]+!![]+!![]+!![]+[])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![])+(+[])+(+[])+(!+[]+!![]+!![])+(!+[]+!![]+!![]+!![])+(!+[]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]))/+((!+[]+!![]+!![]+[])+(!+[]+!![]+!![]+!![]+!![])+(!+[]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![])+(+!![]));zoqqEUY.xzWMiyQ-=+((!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+[])+(!+[]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(+[])+(!+[]+!![]+!![]+!![])+(+!![])+(!+[]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![])+(+!![]))/+((!+[]+!![]+[])+(+!![])+(!+[]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![])+(+!![])+(!+[]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![])+(!+[]+!![]+!![]+!![]));a.value = +zoqqEUY.xzWMiyQ.toFixed(10) + t.length; '; 121'
+        f.action += location.hash;
+        f.submit();
+      }, 4000);
+    }, false);
+  })();
+  //]]>
+</script>
+
+
+</head>
+<body>
+  <table width="100%" height="100%" cellpadding="20">
+    <tr>
+      <td align="center" valign="middle">
+          <div class="cf-browser-verification cf-im-under-attack">
+  <noscript><h1 data-translate="turn_on_js" style="color:#bd2426;">Please turn JavaScript on and reload the page.</h1></noscript>
+  <div id="cf-content" style="display:none">
+
+    <div>
+      <div class="bubbles"></div>
+      <div class="bubbles"></div>
+      <div class="bubbles"></div>
+    </div>
+    <h1><span data-translate="checking_browser">Checking your browser before accessing</span> iload.to.</h1>
+    <p data-translate="process_is_automatic">This process is automatic. Your browser will redirect to your requested content shortly.</p>
+    <p data-translate="allow_5_secs">Please allow up to 5 seconds&hellip;</p>
+  </div>
+
+  <form id="challenge-form" action="/cdn-cgi/l/chk_jschl" method="get">
+    <input type="hidden" name="jschl_vc" value="427c2b1cd4fba29608ee81b200e94bfa"/>
+    <input type="hidden" name="pass" value="1543827239.915-44n9IE20mS"/>
+    <input type="hidden" id="jschl-answer" name="jschl_answer"/>
+  </form>
+</div>
+
+
+          <div class="attribution">
+            <a href="https://www.cloudflare.com/5xx-error-landing?utm_source=iuam" target="_blank" style="font-size: 12px;">DDoS protection by Cloudflare</a>
+            <br>
+            Ray ID: 4834ce407815974a
+          </div>
+      </td>
+
+    </tr>
+  </table>
+</body>
+</html>

--- a/specs/fixtures/js_challenge_03_12_2018_2.html
+++ b/specs/fixtures/js_challenge_03_12_2018_2.html
@@ -1,0 +1,84 @@
+<!DOCTYPE HTML>
+<html lang="en-US">
+<head>
+  <meta charset="UTF-8" />
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=Edge,chrome=1" />
+  <meta name="robots" content="noindex, nofollow" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
+  <title>Just a moment...</title>
+  <style type="text/css">
+    html, body {width: 100%; height: 100%; margin: 0; padding: 0;}
+    body {background-color: #ffffff; font-family: Helvetica, Arial, sans-serif; font-size: 100%;}
+    h1 {font-size: 1.5em; color: #404040; text-align: center;}
+    p {font-size: 1em; color: #404040; text-align: center; margin: 10px 0 0 0;}
+    #spinner {margin: 0 auto 30px auto; display: block;}
+    .attribution {margin-top: 20px;}
+    @-webkit-keyframes bubbles { 33%: { -webkit-transform: translateY(10px); transform: translateY(10px); } 66% { -webkit-transform: translateY(-10px); transform: translateY(-10px); } 100% { -webkit-transform: translateY(0); transform: translateY(0); } }
+    @keyframes bubbles { 33%: { -webkit-transform: translateY(10px); transform: translateY(10px); } 66% { -webkit-transform: translateY(-10px); transform: translateY(-10px); } 100% { -webkit-transform: translateY(0); transform: translateY(0); } }
+    .bubbles { background-color: #404040; width:15px; height: 15px; margin:2px; border-radius:100%; -webkit-animation:bubbles 0.6s 0.07s infinite ease-in-out; animation:bubbles 0.6s 0.07s infinite ease-in-out; -webkit-animation-fill-mode:both; animation-fill-mode:both; display:inline-block; }
+  </style>
+
+    <script type="text/javascript">
+  //<![CDATA[
+  (function(){
+    var a = function() {try{return !!window.addEventListener} catch(e) {return !1} },
+    b = function(b, c) {a() ? document.addEventListener("DOMContentLoaded", b, c) : document.attachEvent("onreadystatechange", b)};
+    b(function(){
+      var a = document.getElementById('cf-content');a.style.display = 'block';
+      setTimeout(function(){
+        var s,t,o,p,b,r,e,a,k,i,n,g,f, qDHeaER={"GrgEgZJzFaa":+((!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+[])+(!+[]+!![]+!![]+!![])+(+!![])+(+[])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(+!![]))/+((!+[]+!![]+!![]+[])+(!+[]+!![]+!![]+!![]+!![])+(!+[]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]))};
+        t = document.createElement('div');
+        t.innerHTML="<a href='/'>x</a>";
+        t = t.firstChild.href;r = t.match(/https?:\/\//)[0];
+        t = t.substr(r.length); t = t.substr(0,t.length-1);
+        a = document.getElementById('jschl-answer');
+        f = document.getElementById('challenge-form');
+        ;qDHeaER.GrgEgZJzFaa*=+((!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+[])+(+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![])+(+[])+(!+[]+!![]+!![]+!![])+(!+[]+!![])+(!+[]+!![]+!![]+!![])+(!+[]+!![]+!![]))/+((!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+[])+(!+[]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![])+(+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]));qDHeaER.GrgEgZJzFaa-=+((!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+[])+(+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![])+(+[])+(!+[]+!![]+!![]+!![])+(!+[]+!![])+(!+[]+!![]+!![]+!![])+(!+[]+!![]+!![]))/+((+!![]+[])+(!+[]+!![]+!![]+!![]+!![])+(+[])+(!+[]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![])+(+!![])+(!+[]+!![]+!![]+!![]+!![]));qDHeaER.GrgEgZJzFaa+=+((!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+[])+(!+[]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![])+(+[])+(!+[]+!![]+!![]))/+((!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+[])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![])+(+!![])+(!+[]+!![]+!![]+!![]+!![]+!![])+(+[])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+!![]));qDHeaER.GrgEgZJzFaa-=+((!+[]+!![]+!![]+!![]+!![]+!![]+!![]+[])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![])+(+[])+(+[])+(!+[]+!![]+!![])+(!+[]+!![]+!![]+!![])+(!+[]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]))/+((!+[]+!![]+!![]+!![]+!![]+!![]+[])+(!+[]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]));qDHeaER.GrgEgZJzFaa-=+((!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+[])+(!+[]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(+[])+(!+[]+!![]+!![]+!![])+(+!![])+(!+[]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]))/+((!+[]+!![]+!![]+!![]+!![]+!![]+[])+(!+[]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![])+(+!![])+(!+[]+!![])+(+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]));qDHeaER.GrgEgZJzFaa+=+((!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+[])+(+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![])+(+[])+(!+[]+!![]+!![]+!![])+(!+[]+!![])+(!+[]+!![]+!![]+!![])+(!+[]+!![]+!![]))/+((!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+[])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![])+(+[])+(+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]));qDHeaER.GrgEgZJzFaa+=+((!+[]+!![]+!![]+!![]+!![]+!![]+!![]+[])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![])+(+[])+(+[])+(!+[]+!![]+!![])+(!+[]+!![]+!![]+!![])+(!+[]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]))/+((!+[]+!![]+!![]+[])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(+[])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![])+(!+[]+!![])+(+[])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![]));qDHeaER.GrgEgZJzFaa*=+((!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+[])+(!+[]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(+[])+(!+[]+!![]+!![]+!![])+(+!![])+(!+[]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![])+(+!![]))/+((!+[]+!![]+!![]+!![]+!![]+!![]+!![]+[])+(+[])+(+!![])+(!+[]+!![]+!![])+(!+[]+!![]+!![])+(+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+!![]));qDHeaER.GrgEgZJzFaa*=+((!+[]+!![]+!![]+!![]+!![]+!![]+!![]+[])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![])+(+[])+(+[])+(!+[]+!![]+!![])+(!+[]+!![]+!![]+!![])+(!+[]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]))/+((!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+[])+(+[])+(!+[]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+!![]));a.value = +qDHeaER.GrgEgZJzFaa.toFixed(10) + t.length; '; 121'
+        f.action += location.hash;
+        f.submit();
+      }, 4000);
+    }, false);
+  })();
+  //]]>
+</script>
+
+
+</head>
+<body>
+  <table width="100%" height="100%" cellpadding="20">
+    <tr>
+      <td align="center" valign="middle">
+          <div class="cf-browser-verification cf-im-under-attack">
+  <noscript><h1 data-translate="turn_on_js" style="color:#bd2426;">Please turn JavaScript on and reload the page.</h1></noscript>
+  <div id="cf-content" style="display:none">
+    <div>
+      <div class="bubbles"></div>
+      <div class="bubbles"></div>
+      <div class="bubbles"></div>
+    </div>
+    <h1><span data-translate="checking_browser">Checking your browser before accessing</span> iload.to.</h1>
+
+    <p data-translate="process_is_automatic">This process is automatic. Your browser will redirect to your requested content shortly.</p>
+    <p data-translate="allow_5_secs">Please allow up to 5 seconds&hellip;</p>
+  </div>
+
+  <form id="challenge-form" action="/cdn-cgi/l/chk_jschl" method="get">
+    <input type="hidden" name="jschl_vc" value="a41fee3a9f041fea01f0cbf3e8e4d29b"/>
+    <input type="hidden" name="pass" value="1543827246.024-hvxyNA3rOg"/>
+    <input type="hidden" id="jschl-answer" name="jschl_answer"/>
+  </form>
+</div>
+
+
+          <div class="attribution">
+            <a href="https://www.cloudflare.com/5xx-error-landing?utm_source=iuam" target="_blank" style="font-size: 12px;">DDoS protection by Cloudflare</a>
+            <br>
+            Ray ID: 4834ce66ab7b9706
+          </div>
+      </td>
+
+    </tr>
+  </table>
+</body>
+</html>

--- a/specs/spec_helper.js
+++ b/specs/spec_helper.js
@@ -38,7 +38,8 @@ module.exports = {
       headers: testDefaults.headers,
       encoding: null, 
       realEncoding: 'utf8', 
-      followAllRedirects: true
+      followAllRedirects: true,
+      challengesToSolve: 3
     }, params);
   }
 };

--- a/specs/spec_helper.js
+++ b/specs/spec_helper.js
@@ -1,12 +1,17 @@
-var fs = require('fs'),
-    urlLib = require('url'),
-    path = require('path');
+var fs = require('fs');
+var urlLib = require('url');
+var path = require('path');
+
+var testDefaults = {
+  url: 'http://example-site.dev/path/',
+  headers: {'User-Agent': 'Chrome'}
+};
 
 module.exports = {
   getFixture: function(fileName) {
     return fs.readFileSync('./specs/fixtures/' + fileName, 'utf8');
   },
-
+  testDefaults: testDefaults,
   // This method returns properly faked response object for request lib, which is used inside cloudscraper library
   fakeResponseObject: function(statusCode, headers, body, url) {
     var parsedUri = urlLib.parse(url);
@@ -25,5 +30,15 @@ module.exports = {
     if (require.cache[pathToLib]) {
       delete require.cache[pathToLib];
     }
+  },
+  requestParams: function(params) {
+    return Object.assign({
+      method: 'GET', 
+      url: testDefaults.url, 
+      headers: testDefaults.headers,
+      encoding: null, 
+      realEncoding: 'utf8', 
+      followAllRedirects: true
+    }, params);
   }
 };

--- a/specs/tests/cloudscraper.js
+++ b/specs/tests/cloudscraper.js
@@ -94,7 +94,8 @@ describe('Cloudscraper', function() {
       },
       encoding: null,
       realEncoding: 'utf8',
-      followAllRedirects: true
+      followAllRedirects: true,
+      challengesToSolve: 2
     })
     .callsArgWith(1, null, response, requestedPage);
 
@@ -136,7 +137,8 @@ describe('Cloudscraper', function() {
       },
       encoding: null,
       realEncoding: 'utf8',
-      followAllRedirects: true
+      followAllRedirects: true,
+      challengesToSolve: 2
     })
     .callsArgWith(1, null, response, requestedPage);
 
@@ -179,7 +181,8 @@ describe('Cloudscraper', function() {
       },
       encoding: null,
       realEncoding: 'utf8',
-      followAllRedirects: true
+      followAllRedirects: true,
+      challengesToSolve: 2
     })
     .callsArgWith(1, null, responseJsChallengePage2, jsChallengePage2);
 
@@ -200,7 +203,8 @@ describe('Cloudscraper', function() {
       },
       encoding: null,
       realEncoding: 'utf8',
-      followAllRedirects: true
+      followAllRedirects: true,
+      challengesToSolve: 1
     })
     .callsArgWith(1, null, responseJsChallengePage2, requestedPage);
 

--- a/specs/tests/cloudscraper.js
+++ b/specs/tests/cloudscraper.js
@@ -1,18 +1,19 @@
-var helper       = require('../spec_helper'),
-    request      = require('request');
+var helper       = require('../spec_helper');
+var request      = require('request');
 
 describe('Cloudscraper', function() {
-  var sandbox,
-      url             = 'http://example-site.dev/path/',
-      requestedPage   = helper.getFixture('requested_page.html'),
-      headers         = {'User-Agent': 'Chrome'},
+  var requestedPage   = helper.getFixture('requested_page.html');
+  var url = helper.testDefaults.url;
+  var headers = helper.testDefaults.headers;
 
-      // Since request.jar returns new cookie jar instance, create one global instance and then stub it in beforeEach
-      jar             = request.jar(),
-      // Since request.defaults returns new wrapper, create one global instance and then stub it in beforeEach
-      requestDefault  = request.defaults({jar: jar}),
-      cloudscraper;
+  // Since request.jar returns new cookie jar instance, create one global instance and then stub it in beforeEach
+  var jar             = request.jar();
+  // Since request.defaults returns new wrapper, create one global instance and then stub it in beforeEach
+  var requestDefault  = request.defaults({jar: jar});
+  var defaultWithArgs = helper.requestParams({});
 
+  var cloudscraper;
+  var sandbox;
   before(function() {
     helper.dropCache();
   });
@@ -36,7 +37,7 @@ describe('Cloudscraper', function() {
 
     // Stub first call, which request makes to page. It should return requested page
     sandbox.stub(requestDefault, 'get')
-      .withArgs({method: 'GET', url: url, headers: headers, encoding: null, realEncoding: 'utf8'})
+      .withArgs(helper.requestParams({}))
       .callsArgWith(1, null, expectedResponse, requestedPage);
 
     cloudscraper.get(url, function(error, response, body) {
@@ -53,7 +54,7 @@ describe('Cloudscraper', function() {
     var pageWithCaptcha = helper.getFixture('page_with_recaptcha.html');
 
     sandbox.stub(requestDefault, 'get')
-      .withArgs({method: 'GET', url: url, headers: headers, encoding: null, realEncoding: 'utf8'})
+      .withArgs(defaultWithArgs)
       .callsArgWith(1, null, expectedResponse, pageWithCaptcha);
 
     cloudscraper.get(url, function(error, response, body) {
@@ -66,13 +67,13 @@ describe('Cloudscraper', function() {
   });
 
   it('should resolve challenge (version as on 21.05.2015) and then return page', function(done) {
-    var jsChallengePage = helper.getFixture('js_challenge_21_05_2015.html'),
-        response = helper.fakeResponseObject(503, headers, jsChallengePage, url),
-        stubbed;
+    var jsChallengePage = helper.getFixture('js_challenge_21_05_2015.html');
+    var response = helper.fakeResponseObject(503, headers, jsChallengePage, url);
+    var stubbed;
 
     // Cloudflare is enabled for site. It returns a page with js challenge
     stubbed = sandbox.stub(requestDefault, 'get')
-      .withArgs({method: 'GET', url: url, headers: headers, encoding: null, realEncoding: 'utf8'})
+      .withArgs(defaultWithArgs)
       .callsArgWith(1, null, response, jsChallengePage);
 
     // Second call to request.get will have challenge solution
@@ -92,7 +93,8 @@ describe('Cloudscraper', function() {
         'Accept': 'application/xml,application/xhtml+xml,text/html;q=0.9, text/plain;q=0.8,image/png,*/*;q=0.5'
       },
       encoding: null,
-      realEncoding: 'utf8'
+      realEncoding: 'utf8',
+      followAllRedirects: true
     })
     .callsArgWith(1, null, response, requestedPage);
 
@@ -107,13 +109,13 @@ describe('Cloudscraper', function() {
   });
 
   it('should resolve challenge (version as on 09.06.2016) and then return page', function(done) {
-    var jsChallengePage = helper.getFixture('js_challenge_09_06_2016.html'),
-        response = helper.fakeResponseObject(503, headers, jsChallengePage, url),
-        stubbed;
+    var jsChallengePage = helper.getFixture('js_challenge_09_06_2016.html');
+    var response = helper.fakeResponseObject(503, headers, jsChallengePage, url);
+    var stubbed;
 
     // Cloudflare is enabled for site. It returns a page with js challenge
     stubbed = sandbox.stub(requestDefault, 'get')
-      .withArgs({method: 'GET', url: url, headers: headers, encoding: null, realEncoding: 'utf8'})
+      .withArgs(defaultWithArgs)
       .callsArgWith(1, null, response, jsChallengePage);
 
     // Second call to request.get will have challenge solution
@@ -133,7 +135,8 @@ describe('Cloudscraper', function() {
         'Accept': 'application/xml,application/xhtml+xml,text/html;q=0.9, text/plain;q=0.8,image/png,*/*;q=0.5'
       },
       encoding: null,
-      realEncoding: 'utf8'
+      realEncoding: 'utf8',
+      followAllRedirects: true
     })
     .callsArgWith(1, null, response, requestedPage);
 
@@ -147,7 +150,7 @@ describe('Cloudscraper', function() {
     this.clock.tick(7000); // tick the timeout
   });
 
-  it.only('should resolve 2 consequent challenges', function(done) {
+  it('should resolve 2 consequent challenges', function(done) {
     var jsChallengePage1 = helper.getFixture('js_challenge_03_12_2018_1.html');
     var jsChallengePage2 = helper.getFixture('js_challenge_03_12_2018_2.html');
     var responseJsChallengePage1 = helper.fakeResponseObject(503, headers, jsChallengePage1, url);
@@ -156,7 +159,7 @@ describe('Cloudscraper', function() {
 
     // First call and CF returns a challenge
     stubbed = sandbox.stub(requestDefault, 'get')
-      .withArgs({method: 'GET', url: url, headers: headers, encoding: null, realEncoding: 'utf8'})
+      .withArgs(defaultWithArgs)
       .callsArgWith(1, null, responseJsChallengePage2, jsChallengePage2);
 
     // We submit a solution to the first challenge, but CF decided to give us a second one
@@ -175,7 +178,8 @@ describe('Cloudscraper', function() {
         'Accept': 'application/xml,application/xhtml+xml,text/html;q=0.9, text/plain;q=0.8,image/png,*/*;q=0.5'
       },
       encoding: null,
-      realEncoding: 'utf8'
+      realEncoding: 'utf8',
+      followAllRedirects: true
     })
     .callsArgWith(1, null, responseJsChallengePage2, jsChallengePage2);
 
@@ -195,7 +199,8 @@ describe('Cloudscraper', function() {
         'Accept': 'application/xml,application/xhtml+xml,text/html;q=0.9, text/plain;q=0.8,image/png,*/*;q=0.5'
       },
       encoding: null,
-      realEncoding: 'utf8'
+      realEncoding: 'utf8',
+      followAllRedirects: true
     })
     .callsArgWith(1, null, responseJsChallengePage2, jsChallengePage2);
 
@@ -210,9 +215,9 @@ describe('Cloudscraper', function() {
   });
 
   it('should make post request with body as string', function(done) {
-    var expectedResponse = { statusCode: 200 },
-        body = 'form-data-body',
-        postHeaders = headers;
+    var expectedResponse = { statusCode: 200 };
+    var body = 'form-data-body';
+    var postHeaders = headers;
 
     postHeaders['Content-Type'] = 'application/x-www-form-urlencoded; charset=UTF-8';
     postHeaders['Content-Length'] = body.length;
@@ -220,7 +225,7 @@ describe('Cloudscraper', function() {
 
     // Stub first call, which request makes to page. It should return requested page
     sandbox.stub(requestDefault, 'post')
-      .withArgs({method: 'POST', url: url, headers: postHeaders, body: body, encoding: null, realEncoding: 'utf8'})
+      .withArgs(helper.requestParams({url: url, method: 'POST', headers: postHeaders, body: body}))
       .callsArgWith(1, null, expectedResponse, requestedPage);
 
     cloudscraper.post(url, body, function(error, response, body) {
@@ -232,17 +237,17 @@ describe('Cloudscraper', function() {
   });
 
   it('should make post request with body as object', function(done) {
-    var expectedResponse = { statusCode: 200 },
-        rawBody = {a: '1', b: 2},
-        encodedBody = 'a=1&b=2',
-        postHeaders = headers;
+    var expectedResponse = { statusCode: 200 };
+    var rawBody = {a: '1', b: 2};
+    var encodedBody = 'a=1&b=2';
+    var postHeaders = headers;
 
     postHeaders['Content-Type'] = 'application/x-www-form-urlencoded; charset=UTF-8';
     postHeaders['Content-Length'] = encodedBody.length;
 
     // Stub first call, which request makes to page. It should return requested page
     sandbox.stub(requestDefault, 'post')
-      .withArgs({method: 'POST', url: url, headers: postHeaders, body: encodedBody, encoding: null, realEncoding: 'utf8'})
+      .withArgs(helper.requestParams({url: url, method: 'POST', headers: postHeaders, body: encodedBody}))
       .callsArgWith(1, null, expectedResponse, requestedPage);
 
     cloudscraper.post(url, rawBody, function(error, response, body) {
@@ -256,16 +261,17 @@ describe('Cloudscraper', function() {
   it('should return raw data when encoding is null', function(done) {
     var expectedResponse = { statusCode: 200 };
     var requestedData = new Buffer('R0lGODlhDwAPAKECAAAAzMzM/////wAAACwAAAAADwAPAAACIISPeQHsrZ5ModrLlN48CXF8m2iQ3YmmKqVlRtW4MLwWACH+H09wdGltaXplZCBieSBVbGVhZCBTbWFydFNhdmVyIQAAOw==', 'base64');
-
+    
     sandbox.stub(requestDefault, 'get')
-      .withArgs({method: 'GET', url: url, headers: headers, encoding: null, realEncoding: null})
+      .withArgs(helper.requestParams({url: url, headers: headers, encoding: null, realEncoding: null}))
       .callsArgWith(1, null, expectedResponse, requestedData);
 
     var options = {
       method: 'GET',
       url: url,
       encoding: null,
-      headers: headers
+      headers: headers,
+      followAllRedirects: true
     };
 
     cloudscraper.request(options, function(error, response, body) {
@@ -277,9 +283,8 @@ describe('Cloudscraper', function() {
   });
 
   it('should set the given cookie and then return page', function(done) {
-    var jsChallengePage = helper.getFixture('js_challenge_cookie.html'),
-        response = helper.fakeResponseObject(200, headers, jsChallengePage, url),
-        stubbed;
+    var jsChallengePage = helper.getFixture('js_challenge_cookie.html');
+    var response = helper.fakeResponseObject(200, headers, jsChallengePage, url);
 
     // Cloudflare is enabled for site.
     // It returns a redirecting page if a (session) cookie is unset.

--- a/specs/tests/cloudscraper.js
+++ b/specs/tests/cloudscraper.js
@@ -150,13 +150,14 @@ describe('Cloudscraper', function() {
   it('should resolve 2 consequent challenges', function(done) {
     var jsChallengePage1 = helper.getFixture('js_challenge_03_12_2018_1.html');
     var jsChallengePage2 = helper.getFixture('js_challenge_03_12_2018_2.html');
-    var responsejsChallengePage1 = helper.fakeResponseObject(503, headers, jsChallengePage1, url);
-    var responsejsChallengePage2 = helper.fakeResponseObject(503, headers, jsChallengePage2, url);
+    var responseJsChallengePage1 = helper.fakeResponseObject(503, headers, jsChallengePage1, url);
+    var responseJsChallengePage2 = helper.fakeResponseObject(503, headers, jsChallengePage2, url);
     var stubbed;
 
     stubbed = sandbox.stub(requestDefault, 'get')
       .withArgs({method: 'GET', url: url, headers: headers, encoding: null, realEncoding: 'utf8'})
-      .callsArgWith(1, null, response, jsChallengePage);
+      .callsArgWith(1, null, responseJsChallengePage1, jsChallengePage1);
+      
   });
 
   it('should make post request with body as string', function(done) {

--- a/specs/tests/cloudscraper.js
+++ b/specs/tests/cloudscraper.js
@@ -160,7 +160,7 @@ describe('Cloudscraper', function() {
     // First call and CF returns a challenge
     stubbed = sandbox.stub(requestDefault, 'get')
       .withArgs(defaultWithArgs)
-      .callsArgWith(1, null, responseJsChallengePage2, jsChallengePage2);
+      .callsArgWith(1, null, responseJsChallengePage1, jsChallengePage1);
 
     // We submit a solution to the first challenge, but CF decided to give us a second one
     stubbed.withArgs({
@@ -202,7 +202,7 @@ describe('Cloudscraper', function() {
       realEncoding: 'utf8',
       followAllRedirects: true
     })
-    .callsArgWith(1, null, responseJsChallengePage2, jsChallengePage2);
+    .callsArgWith(1, null, responseJsChallengePage2, requestedPage);
 
     cloudscraper.get(url, function(error, response, body) {
       expect(error).to.be.null();
@@ -211,7 +211,7 @@ describe('Cloudscraper', function() {
       done();
     }, headers);
 
-    this.clock.tick(7000); // tick the timeout
+    this.clock.tick(14000); // tick the timeout
   });
 
   it('should make post request with body as string', function(done) {

--- a/specs/tests/cloudscraper.js
+++ b/specs/tests/cloudscraper.js
@@ -147,6 +147,18 @@ describe('Cloudscraper', function() {
     this.clock.tick(7000); // tick the timeout
   });
 
+  it('should resolve 2 consequent challenges', function(done) {
+    var jsChallengePage1 = helper.getFixture('js_challenge_03_12_2018_1.html');
+    var jsChallengePage2 = helper.getFixture('js_challenge_03_12_2018_2.html');
+    var responsejsChallengePage1 = helper.fakeResponseObject(503, headers, jsChallengePage1, url);
+    var responsejsChallengePage2 = helper.fakeResponseObject(503, headers, jsChallengePage2, url);
+    var stubbed;
+
+    stubbed = sandbox.stub(requestDefault, 'get')
+      .withArgs({method: 'GET', url: url, headers: headers, encoding: null, realEncoding: 'utf8'})
+      .callsArgWith(1, null, response, jsChallengePage);
+  });
+
   it('should make post request with body as string', function(done) {
     var expectedResponse = { statusCode: 200 },
         body = 'form-data-body',

--- a/specs/tests/errors.js
+++ b/specs/tests/errors.js
@@ -1,18 +1,19 @@
-var helper       = require('../spec_helper'),
-    request      = require('request');
+var helper       = require('../spec_helper');
+var request      = require('request');
 
 describe('Cloudscraper', function() {
-  var sandbox,
-      url               = 'http://example-site.dev/path/',
-      captchaPage       = helper.getFixture('captcha.html'),
-      accessDenied      = helper.getFixture('access_denied.html'),
-      invalidChallenge  = helper.getFixture('invalid_js_challenge.html'),
-      headers           = {'User-Agent': 'Chrome'},
+  var sandbox;
+  var captchaPage       = helper.getFixture('captcha.html');
+  var accessDenied      = helper.getFixture('access_denied.html');
+  var invalidChallenge  = helper.getFixture('invalid_js_challenge.html');
+  var url = helper.testDefaults.url;
+  var headers = helper.testDefaults.headers;
 
-      // Since request.defaults returns new wrapper, create one global instance and then stub it in beforeEach
-      requestDefault  = request.defaults({jar: true}),
-      cloudscraper;
+  // Since request.defaults returns new wrapper, create one global instance and then stub it in beforeEach
+  var requestDefault  = request.defaults({jar: true});
+  var defaultWithArgs = helper.requestParams({});
 
+  var cloudscraper;
   before(function() {
     helper.dropCache();
   });
@@ -35,7 +36,7 @@ describe('Cloudscraper', function() {
         fakeError = {fake: 'error'}; //not real request error, but it doesn't matter
 
     sandbox.stub(requestDefault, 'get')
-      .withArgs({method: 'GET', url: url, headers: headers, encoding: null, realEncoding: 'utf8'})
+      .withArgs(defaultWithArgs)
       .callsArgWith(1, fakeError, response, '');
 
     cloudscraper.get(url, function(error) {
@@ -49,7 +50,7 @@ describe('Cloudscraper', function() {
     var response = { statusCode: 503 };
 
     sandbox.stub(requestDefault, 'get')
-      .withArgs({method: 'GET', url: url, headers: headers, encoding: null, realEncoding: 'utf8'})
+      .withArgs(defaultWithArgs)
       .callsArgWith(1, null, response, captchaPage);
 
     cloudscraper.get(url, function(error, body) {
@@ -64,7 +65,7 @@ describe('Cloudscraper', function() {
     var response = { statusCode: 500 };
 
     sandbox.stub(requestDefault, 'get')
-      .withArgs({method:'GET', url: url, headers: headers, encoding: null, realEncoding: 'utf8'})
+      .withArgs(defaultWithArgs)
       .callsArgWith(1, null, response, accessDenied);
 
     cloudscraper.get(url, function(error, body) {
@@ -79,7 +80,7 @@ describe('Cloudscraper', function() {
     var response = { statusCode: 500 };
 
     sandbox.stub(requestDefault, 'get')
-      .withArgs({method:'GET', url: url, headers: headers, encoding: null, realEncoding: 'utf8'})
+      .withArgs(defaultWithArgs)
       .callsArgWith(1, null, response, undefined);
 
     cloudscraper.get(url, function(error, body) {
@@ -92,7 +93,7 @@ describe('Cloudscraper', function() {
   it('should return error if challenge page failed to be parsed', function(done) {
     var response = helper.fakeResponseObject(200, headers, invalidChallenge, url);
     sandbox.stub(requestDefault, 'get')
-      .withArgs({method: 'GET', url: url, headers: headers, encoding: null, realEncoding: 'utf8'})
+      .withArgs(defaultWithArgs)
       .callsArgWith(1, null, response, invalidChallenge);
 
     cloudscraper.get(url, function(error, body) {
@@ -135,7 +136,7 @@ describe('Cloudscraper', function() {
     var pageWithCaptchaResponse = { statusCode: 200 };
     // Cloudflare is enabled for site. It returns a page with js challenge
     stubbed = sandbox.stub(requestDefault, 'get')
-      .withArgs({method: 'GET', url: url, headers: headers, encoding: null, realEncoding: 'utf8'})
+      .withArgs(helper.requestParams({url: url, headers: headers}))
       .callsArgWith(1, null, response, jsChallengePage);
 
     // Second call to request.get returns recaptcha
@@ -145,7 +146,8 @@ describe('Cloudscraper', function() {
       qs: sinon.match.any,
       headers: sinon.match.any,
       encoding: null,
-      realEncoding: 'utf8'
+      realEncoding: 'utf8',
+      followAllRedirects: true
     })
     .callsArgWith(1, null, pageWithCaptchaResponse, captchaPage);
 

--- a/specs/tests/errors.js
+++ b/specs/tests/errors.js
@@ -147,7 +147,8 @@ describe('Cloudscraper', function() {
       headers: sinon.match.any,
       encoding: null,
       realEncoding: 'utf8',
-      followAllRedirects: true
+      followAllRedirects: true,
+      challengesToSolve: 2
     })
     .callsArgWith(1, null, pageWithCaptchaResponse, captchaPage);
 

--- a/specs/tests/errors.js
+++ b/specs/tests/errors.js
@@ -53,9 +53,9 @@ describe('Cloudscraper', function() {
       .withArgs(defaultWithArgs)
       .callsArgWith(1, null, response, captchaPage);
 
-    cloudscraper.get(url, function(error, body) {
+    cloudscraper.get(url, function(error, body, response) {
       expect(error).to.be.eql({errorType: 1}); // errorType 1, means captcha is served
-      expect(body).to.be.eql(captchaPage);
+      expect(response).to.be.eql(captchaPage);
       done();
     }, headers);
   });
@@ -68,9 +68,9 @@ describe('Cloudscraper', function() {
       .withArgs(defaultWithArgs)
       .callsArgWith(1, null, response, accessDenied);
 
-    cloudscraper.get(url, function(error, body) {
+    cloudscraper.get(url, function(error, body, response) {
       expect(error).to.be.eql({errorType: 2, error: 1006}); // errorType 2, means inner cloudflare error
-      expect(body).to.be.eql(accessDenied);
+      expect(response).to.be.eql(accessDenied);
       done();
     }, headers);
   });
@@ -83,9 +83,9 @@ describe('Cloudscraper', function() {
       .withArgs(defaultWithArgs)
       .callsArgWith(1, null, response, undefined);
 
-    cloudscraper.get(url, function(error, body) {
+    cloudscraper.get(url, function(error, body, response) {
       expect(error).to.be.eql({errorType: 0, error: null}); // errorType 2, means inner cloudflare error
-      expect(body).to.be.eql(undefined);
+      expect(response).to.be.eql(undefined);
       done();
     }, headers);
   });
@@ -96,9 +96,9 @@ describe('Cloudscraper', function() {
       .withArgs(defaultWithArgs)
       .callsArgWith(1, null, response, invalidChallenge);
 
-    cloudscraper.get(url, function(error, body) {
+    cloudscraper.get(url, function(error, body, response) {
       expect(error.errorType).to.be.eql(3); // errorType 3, means parsing failed
-      expect(body).to.be.eql(invalidChallenge);
+      expect(response).to.be.eql(invalidChallenge);
       done();
     }, headers);
 
@@ -151,9 +151,9 @@ describe('Cloudscraper', function() {
     })
     .callsArgWith(1, null, pageWithCaptchaResponse, captchaPage);
 
-    cloudscraper.get(url, function(error, response, body) {
+    cloudscraper.get(url, function(error, body, response) {
       expect(error).to.be.eql({errorType: 1}); // errorType 1, means captcha is served
-      expect(body).to.be.eql(captchaPage);
+      expect(response).to.be.eql(captchaPage);
       done();
     }, headers);
 


### PR DESCRIPTION
Fixes issue #65 

What has been done:
- Everytime CF returns any response, check it for errors, new challenge, captcha or so
- Remove manual 302 processing, use `followAllRedirects` flag from the request library
- **BREAKING CHANGE** Before this, when any error has been detected, the callback was called with an incorrect order: `callback(.., body, response);` instead of `return callback(..., response, body);`
- Some code fixes, cleanup and so

What yet to be done:
- [x] Set a limit of recursive calls, to prevent many requests to be done
- [ ] Bump major version before releasing