### PR TITLE
Promise Support

### DIFF
--- a/index.js
+++ b/index.js
@@ -71,6 +71,7 @@ function processRequestResponse(options, requestResult, callback) {
   var isRedirectChallengePresent;
 
   if (error || !body || !body.toString) {
+    // Pure request error (bad connection, wrong url, etc)
     return callback({ errorType: 0, error: error }, response, body);
   }
 
@@ -103,11 +104,6 @@ function processRequestResponse(options, requestResult, callback) {
 
 function checkForErrors(error, body) {
   var match;
-
-  // Pure request error (bad connection, wrong url, etc)
-  if(error) {
-    return { errorType: 0, error: error };
-  }
 
   // Finding captcha
   if (body.indexOf('why_captcha') !== -1 || /cdn-cgi\/l\/chk_captcha/i.test(body)) {

--- a/index.js
+++ b/index.js
@@ -189,9 +189,9 @@ function setCookieAndReload(response, body, options, callback) {
     document: {}
   };
 
-  vm.runInNewContext(cookieSettingCode, sandbox);
-
   try {
+    vm.runInNewContext(cookieSettingCode, sandbox);
+
     options.jar.setCookie(sandbox.document.cookie, response.request.uri.href, {ignoreError: true});
   } catch (err) {
     return callback({errorType: 3, error: 'Error occurred during evaluation: ' +  err.message}, response, body);

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
   "license": "MIT",
   "homepage": "https://github.com/codemanki/cloudscraper",
   "dependencies": {
-    "request": "^2.87.0"
+    "request": "^2.88.0",
+    "request-promise": "^4.2.4"
   },
   "devDependencies": {
     "chai": "^4.2.0",

--- a/test/test-errors.js
+++ b/test/test-errors.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var cloudscraper = require('../index');
-var request      = require('request');
+var request      = require('request-promise');
 var helper       = require('./helper');
 
 var sinon   = require('sinon');

--- a/test/test-index.js
+++ b/test/test-index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var cloudscraper = require('../index');
-var request      = require('request');
+var request      = require('request-promise');
 var helper       = require('./helper');
 
 var sinon   = require('sinon');

--- a/test/test-index.js
+++ b/test/test-index.js
@@ -337,4 +337,12 @@ describe('Cloudscraper', function() {
       done();
     });
   });
+
+  it('should define custom defaults function', function (done) {
+    expect(cloudscraper.defaults).to.not.equal(request.defaults);
+
+    var custom = cloudscraper.defaults({ challengesToSolve: 5 });
+    expect(custom.defaults).to.equal(cloudscraper.defaults);
+    done();
+  });
 });


### PR DESCRIPTION
***Don't merge.*** I'll need to rebase this once #91 is merged as it's based on it.
This could use some `request-promise` specific tests. Other than that, it's good. I don't think code coverage was decreased.

It adds request-promise as a dependency and makes adjustments where necessary. It is completely backwards compatible with the v3.0.0 branch and all tests are passing for me. I had forgot that request was a peer dependency of request-promise and the CI build failed...lol, It's fixed now.

Closes #92 
And the following PRs
Closes #43 
Closes #30 