### PR TITLE
Fix promise support

### DIFF
--- a/errors.js
+++ b/errors.js
@@ -1,0 +1,75 @@
+'use strict';
+
+var original = require('request-promise-core/errors');
+var OriginalError = original.RequestError;
+
+// The purpose of this library is two-fold.
+// 1. Have errors consistent with request/promise-core
+// 2. Prevent request/promise core from wrapping our errors
+
+// There are two differences between these errors and the originals.
+// 1. There is a non-enumerable errorType attribute.
+// 2. The error constructor is hidden from the stacktrace.
+
+function create(name, errorType) {
+  function CustomError(cause, options, response) {
+
+    // This prevents nasty things e.g. `error.cause.error` and
+    // is why replacing the original RequestError is necessary.
+    if (cause instanceof OriginalError) {
+      return cause;
+    }
+
+    OriginalError.apply(this, arguments);
+
+    // Change the name to match this constructor
+    this.name = name;
+
+    if (Error.captureStackTrace) { // required for non-V8 environments
+      // Provide a proper stack trace that hides this constructor
+      Error.captureStackTrace(this, CustomError);
+    }
+  }
+
+  CustomError.prototype = Object.create(OriginalError.prototype);
+  CustomError.prototype.constructor = CustomError;
+  // Keeps things stealthy by defining errorType on the prototype.
+  // This makes it non-enumerable and safer to add.
+  CustomError.prototype.errorType = errorType;
+
+  Object.setPrototypeOf(CustomError, Object.getPrototypeOf(OriginalError));
+  Object.defineProperty(CustomError, 'name', {
+    configurable: true,
+    value: name
+  });
+
+  return CustomError;
+}
+
+var RequestError    = create('RequestError', 0);
+var CaptchaError    = create('CaptchaError', 1);
+var CloudflareError = create('CloudflareError', 2);
+var ParserError     = create('ParserError', 3);
+// errorType 4 is a CloudflareError so that constructor is reused.
+
+// The following errors originate from promise-core and it's dependents.
+// Give them an errorType for consistency.
+original.StatusCodeError.prototype.errorType = 5;
+original.TransformError.prototype.errorType = 6;
+
+// This replaces the RequestError for all libraries using request/promise-core
+// and prevents silent failure.
+Object.defineProperty(original, 'RequestError', {
+  configurable: true,
+  enumerable: true,
+  writable: true,
+  value: RequestError
+});
+
+// Export our custom errors along with StatusCodeError, etc.
+Object.assign(module.exports, original, {
+  RequestError: RequestError,
+  CaptchaError: CaptchaError,
+  ParserError: ParserError,
+  CloudflareError: CloudflareError
+});

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 var vm = require('vm');
 var requestModule = require('request-promise');
+var errors = require('./errors');
 
 module.exports = defaults.call(requestModule);
 
@@ -105,24 +106,27 @@ function performRequest(options, isFirstRequest) {
   return request;
 }
 
-function processRequestResponse(options, requestResult, callback) {
-  var error = requestResult.error;
-  var response = requestResult.response;
-  var body = requestResult.body;
-  var validationError;
+function processRequestResponse(options, result, callback) {
+  var error = result.error;
+  var response = result.response;
+  var body = result.body;
   var stringBody;
   var isChallengePresent;
   var isRedirectChallengePresent;
 
   if (error || !body || !body.toString) {
     // Pure request error (bad connection, wrong url, etc)
-    return callback({ errorType: 0, error: error }, response, body);
+    error = new errors.RequestError(error, options, response);
+
+    return callback(error, response, body);
   }
 
   stringBody = body.toString('utf8');
 
-  if (validationError = checkForErrors(error, stringBody)) {
-    return callback(validationError, response, body);
+  try {
+    validate(response, stringBody, options);
+  } catch (error) {
+    return callback(error, response, body);
   }
 
   isChallengePresent = stringBody.indexOf('a = document.getElementById(\'jschl-answer\');') !== -1;
@@ -130,7 +134,11 @@ function processRequestResponse(options, requestResult, callback) {
   // isTargetPage = !isChallengePresent && !isRedirectChallengePresent;
 
   if (isChallengePresent && options.challengesToSolve === 0) {
-    return callback({ errorType: 4 }, response, body);
+    var cause = 'Cloudflare challenge loop';
+    error = new errors.CloudflareError(cause, options, response);
+    error.errorType = 4;
+
+    return callback(error, response, body);
   }
 
   // If body contains specified string, solve challenge
@@ -142,23 +150,24 @@ function processRequestResponse(options, requestResult, callback) {
     setCookieAndReload(response, stringBody, options, callback);
   } else {
     // All is good
-    processResponseBody(options, error, response, body, callback);
+    processResponseBody(response, body, options, callback);
   }
 }
 
-function checkForErrors(error, body) {
+function validate(response, body, options) {
   var match;
 
   // Finding captcha
   if (body.indexOf('why_captcha') !== -1 || /cdn-cgi\/l\/chk_captcha/i.test(body)) {
-    return { errorType: 1 };
+    throw new errors.CaptchaError('captcha', options, response);
   }
 
   // trying to find '<span class="cf-error-code">1006</span>'
   match = body.match(/<\w+\s+class="cf-error-code">(.*)<\/\w+>/i);
 
   if (match) {
-    return { errorType: 2, error: parseInt(match[1]) };
+    var code = parseInt(match[1]);
+    throw new errors.CloudflareError(code, options, response);
   }
 
   return false;
@@ -170,9 +179,14 @@ function solveChallenge(response, body, options, callback) {
   var jsChlVc;
   var answerResponse;
   var answerUrl;
+  var error;
+  var cause;
 
   if (!challenge) {
-    return callback({errorType: 3, error: 'I cant extract challengeId (jschl_vc) from page'}, response, body);
+    cause = 'challengeId (jschl_vc) extraction failed';
+    error = new errors.ParserError(cause, options, response);
+
+    return callback(error, response, body);
   }
 
   jsChlVc = challenge[1];
@@ -180,7 +194,10 @@ function solveChallenge(response, body, options, callback) {
   challenge = body.match(/getElementById\('cf-content'\)[\s\S]+?setTimeout.+?\r?\n([\s\S]+?a\.value =.+?)\r?\n/i);
 
   if (!challenge) {
-    return callback({errorType: 3, error: 'I cant extract method from setTimeOut wrapper'}, response, body);
+    cause = 'setTimeout callback extraction failed';
+    error = new errors.ParserError(cause, options, response);
+
+    return callback(error, response, body);
   }
 
   var challenge_pass = body.match(/name="pass" value="(.+?)"/)[1];
@@ -198,8 +215,11 @@ function solveChallenge(response, body, options, callback) {
       'jschl_answer': (eval(challenge) + response.request.host.length),
       'pass': challenge_pass
     };
-  } catch (err) {
-    return callback({errorType: 3, error: 'Error occurred during evaluation: ' +  err.message}, response, body);
+  } catch (error) {
+    error.message = 'Challenge evaluation failed: ' + error.message;
+    error = new errors.ParserError(error, options, response);
+
+    return callback(error, response, body);
   }
 
   answerUrl = response.request.uri.protocol + '//' + host + '/cdn-cgi/l/chk_jschl';
@@ -220,7 +240,10 @@ function setCookieAndReload(response, body, options, callback) {
   var challenge = body.match(/S='([^']+)'/);
 
   if (!challenge) {
-    return callback({errorType: 3, error: 'I cant extract cookie generation code from page'}, response, body);
+    var cause = 'Cookie code extraction failed';
+    var error = new errors.ParserError(cause, options, response);
+
+    return callback(error, response, body);
   }
 
   var base64EncodedCode = challenge[1];
@@ -237,8 +260,11 @@ function setCookieAndReload(response, body, options, callback) {
     vm.runInNewContext(cookieSettingCode, sandbox);
 
     options.jar.setCookie(sandbox.document.cookie, response.request.uri.href, {ignoreError: true});
-  } catch (err) {
-    return callback({errorType: 3, error: 'Error occurred during evaluation: ' +  err.message}, response, body);
+  } catch (error) {
+    error.message = 'Cookie code evaluation failed: ' + error.message;
+    error = new errors.ParserError(error, options, response);
+
+    return callback(error, response, body);
   }
 
   options.challengesToSolve = options.challengesToSolve - 1;
@@ -246,7 +272,9 @@ function setCookieAndReload(response, body, options, callback) {
   performRequest(options, false);
 }
 
-function processResponseBody(options, error, response, body, callback) {
+function processResponseBody(response, body, options, callback) {
+  var error = null;
+
   if(typeof options.realEncoding === 'string') {
     body = body.toString(options.realEncoding);
     // The resolveWithFullResponse option will resolve with the response object.
@@ -256,8 +284,10 @@ function processResponseBody(options, error, response, body, callback) {
     // In case of real encoding, try to validate the response
     // and find potential errors there.
     // If encoding is not provided, return response as it is
-    if (validationError = checkForErrors(error, body)) {
-      return callback(validationError, response, body);
+    try {
+      validate(response, body, options);
+    } catch (e) {
+      error = e;
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   },
   "devDependencies": {
     "chai": "^4.2.0",
+    "chai-as-promised": "^7.1.1",
     "coveralls": "^3.0.3",
     "eslint": "^5.14.1",
     "eslint-config-standard": "^12.0.0",

--- a/test/common.js
+++ b/test/common.js
@@ -3,4 +3,6 @@
 var chai = require('chai');
 
 chai.use(require('sinon-chai'));
+chai.use(require('chai-as-promised'));
+
 chai.config.includeStack = true;

--- a/test/rp.js
+++ b/test/rp.js
@@ -1,0 +1,35 @@
+'use strict';
+
+// Reproduces: https://github.com/request/request-promise/blob/6d11ddc63dde2462a8e39cd8d0b6956556b977f1/lib/rp.js
+
+// This library almost exactly reproduces the real rp library.
+// The primary difference being that we're pre-patching the init method.
+// It must be done this way because request-promise bypasses require.cache.
+
+var Bluebird = require('bluebird').getNewLibraryCopy();
+var configure = require('request-promise-core/configure/request2');
+var request = require('request');
+
+// The real rp library works by replacing this init function.
+// It will store the original callback from options,
+// apply our init function, and wrap the request instance's callback.
+function init(options) {
+  // Request -> Request.prototype.init -> Request.prototype.start
+  // The test/helper is responsible for calling back with a fake response.
+}
+
+// Replacing init with a noop prevents real requests from being made.
+request.Request.prototype.init = init;
+
+configure({
+  request: request,
+  PromiseImpl: Bluebird,
+  expose: [
+    'then',
+    'catch',
+    'finally',
+    'promise'
+  ]
+});
+
+module.exports = request;

--- a/test/test-errors.js
+++ b/test/test-errors.js
@@ -2,10 +2,12 @@
 
 var cloudscraper = require('../index');
 var request      = require('request-promise');
+var RequestError = require('request-promise/errors').RequestError;
 var helper       = require('./helper');
 
 var sinon   = require('sinon');
 var expect  = require('chai').expect;
+var assert = require('chai').assert;
 
 describe('Cloudscraper', function() {
   var uri = helper.defaultParams.uri;
@@ -30,70 +32,69 @@ describe('Cloudscraper', function() {
 
     Request.callsFake(helper.fakeRequest({ error: fakeError }));
 
-    cloudscraper.get(uri, function(error) {
+    var promise = cloudscraper.get(uri, function (error) {
       // errorType 0, means it is some kind of system error
       expect(error).to.be.an('object');
       expect(error).to.be.eql({ errorType: 0, error: fakeError });
       expect(error.error).to.be.an('error');
 
-      expect(Request).to.be.calledOnce;
-      expect(Request.firstCall).to.be.calledWithExactly(helper.defaultParams);
-      done();
+      expect(Request).to.be.calledOnceWithExactly(helper.defaultParams);
     });
 
+    expect(promise).to.be.rejectedWith(RequestError).and.notify(done);
   });
 
   it('should return error if captcha is served by cloudflare', function(done) {
-    var onlyResponse = helper.fakeResponse({
+    var expectedResponse = helper.fakeResponse({
       statusCode: 503,
       body: helper.getFixture('captcha.html')
     });
 
-    Request.callsFake(helper.fakeRequest({ response: onlyResponse }));
+    Request.callsFake(helper.fakeRequest({ response: expectedResponse }));
 
-    cloudscraper.get(uri, function(error, response, body) {
+    var promise = cloudscraper.get(uri, function (error, response, body) {
       // errorType 1, means captcha is served
       expect(error).to.be.an('object');
       expect(error).to.be.eql({ errorType: 1 });
 
-      expect(Request).to.be.calledOnce;
-      expect(Request.firstCall).to.be.calledWithExactly(helper.defaultParams);
+      expect(Request).to.be.calledOnceWithExactly(helper.defaultParams);
 
-      expect(response).to.be.equal(onlyResponse);
-      expect(body).to.be.equal(onlyResponse.body);
-      done();
+      expect(response).to.be.equal(expectedResponse);
+      expect(body).to.be.equal(expectedResponse.body);
     });
+
+    expect(promise).to.be.rejectedWith(RequestError).and.notify(done);
   });
 
   it('should return error if cloudflare returned some inner error', function(done) {
     // https://support.cloudflare.com/hc/en-us/sections/200038216-CloudFlare-Error-Messages
     // Error codes: 1012, 1011, 1002, 1000, 1004, 1010, 1006, 1007, 1008
 
-    var onlyResponse = helper.fakeResponse({
+    var expectedResponse = helper.fakeResponse({
       statusCode: 500,
       body: helper.getFixture('access_denied.html')
     });
 
-    Request.callsFake(helper.fakeRequest({ response: onlyResponse }));
+    Request.callsFake(helper.fakeRequest({ response: expectedResponse }));
 
-    cloudscraper.get(uri, function(error, response, body) {
+    var promise = cloudscraper.get(uri, function (error, response, body) {
       // errorType 2, means inner cloudflare error
       expect(error).to.be.an('object');
       expect(error).to.be.eql({ errorType: 2, error: 1006 });
 
-      expect(Request).to.be.calledOnce;
-      expect(Request.firstCall).to.be.calledWithExactly(helper.defaultParams);
+      expect(Request).to.be.calledOnceWithExactly(helper.defaultParams);
 
-      expect(response).to.be.equal(onlyResponse);
-      expect(body).to.be.equal(onlyResponse.body);
-      done();
+      expect(response).to.be.equal(expectedResponse);
+      expect(body).to.be.equal(expectedResponse.body);
     });
+
+    expect(promise).to.be.rejectedWith(RequestError).and.notify(done);
   });
-  
+
   it('should return error if cf presented more than 3 challenges in a row', function(done) {
     // The expected params for all subsequent calls to Request
     var expectedParams = helper.extendParams({
-      uri: 'http://example-site.dev/cdn-cgi/l/chk_jschl',
+      uri: 'http://example-site.dev/cdn-cgi/l/chk_jschl'
     });
 
     // Perform less strict matching on headers and qs to simplify this test
@@ -110,11 +111,11 @@ describe('Cloudscraper', function() {
 
     Request.callsFake(helper.fakeRequest({ response: expectedResponse }));
 
-    cloudscraper.get(uri, function(error, response, body) {
+    var promise = cloudscraper.get(uri, function (error, response, body) {
       expect(error).to.be.an('object');
       expect(error).to.be.eql({ errorType: 4 });
 
-      expect(Request.callCount).to.be.equal(4);
+      assert.equal(Request.callCount, 4, 'Request call count');
       expect(Request.firstCall).to.be.calledWithExactly(helper.defaultParams);
 
       var total = helper.defaultParams.challengesToSolve + 1;
@@ -126,10 +127,12 @@ describe('Cloudscraper', function() {
 
       expect(response).to.be.equal(expectedResponse);
       expect(body).to.be.equal(expectedResponse.body);
-      done();
     });
 
-    this.clock.tick(200000); // tick the timeout
+    expect(promise).to.be.rejectedWith(RequestError).and.notify(done);
+
+    // Tick the timeout
+    this.clock.tick(200000);
   });
 
   it('should return error if body is undefined', function(done) {
@@ -140,102 +143,102 @@ describe('Cloudscraper', function() {
       response: { statusCode: 500}
     }));
 
-    cloudscraper.get(uri, function(error, response, body) {
+    var promise = cloudscraper.get(uri, function (error, response, body) {
       // errorType 2, means inner cloudflare error
       expect(error).to.be.an('object');
       expect(error).to.be.eql({ errorType: 0, error: null });
 
-      expect(Request).to.be.calledOnce;
-      expect(Request.firstCall).to.be.calledWithExactly(helper.defaultParams);
+      expect(Request).to.be.calledOnceWithExactly(helper.defaultParams);
 
       expect(body).to.be.equal(undefined);
-      done();
     });
+
+    expect(promise).to.be.rejectedWith(RequestError).and.notify(done);
   });
 
   it('should return error if challenge page failed to be parsed', function(done) {
-    var onlyResponse = helper.fakeResponse({
+    var expectedResponse = helper.fakeResponse({
       body: helper.getFixture('invalid_js_challenge.html')
     });
 
-    Request.callsFake(helper.fakeRequest({ response: onlyResponse }));
+    Request.callsFake(helper.fakeRequest({ response: expectedResponse }));
 
-    cloudscraper.get(uri, function(error, response, body) {
+    var promise = cloudscraper.get(uri, function (error, response, body) {
       // errorType 3, means parsing failed
       expect(error).to.be.an('object');
       expect(error).to.own.include({ errorType: 3 });
 
-      expect(Request).to.be.calledOnce;
-      expect(Request).to.be.calledWithExactly(helper.defaultParams);
+      expect(Request).to.be.calledOnceWithExactly(helper.defaultParams);
 
-      expect(response).to.be.equal(onlyResponse);
-      expect(body).to.be.equal(onlyResponse.body);
-      done();
+      expect(response).to.be.equal(expectedResponse);
+      expect(body).to.be.equal(expectedResponse.body);
     });
+
+    expect(promise).to.be.rejectedWith(RequestError).and.notify(done);
 
     this.clock.tick(7000); // tick the timeout
   });
 
   it('should return error if js challenge has error during evaluation', function(done) {
-    var onlyResponse = helper.fakeResponse({
+    var expectedResponse = helper.fakeResponse({
       statusCode: 503,
       body: helper.getFixture('js_challenge_03_12_2018_1.html')
     });
 
     // Adds a syntax error near the end of line 37
-    onlyResponse.body = onlyResponse.body.replace(/\.toFixed/gm, '..toFixed');
+    expectedResponse.body = expectedResponse.body.replace(/\.toFixed/gm, '..toFixed');
 
-    Request.callsFake(helper.fakeRequest({ response: onlyResponse }));
+    Request.callsFake(helper.fakeRequest({ response: expectedResponse }));
 
-    cloudscraper.get(uri, function(error, response, body) {
+    var promise = cloudscraper.get(uri, function (error, response, body) {
       // errorType 3, means parsing failed
       expect(error).to.be.an('object');
       expect(error).to.own.include({ errorType: 3 });
       expect(error.error).to.be.a('string');
       expect(error.error).to.include('Error occurred during evaluation: ');
 
-      expect(Request).to.be.calledOnce;
-      expect(Request).to.be.calledWithExactly(helper.defaultParams);
+      expect(Request).to.be.calledOnceWithExactly(helper.defaultParams);
 
-      expect(response).to.be.equal(onlyResponse);
-      expect(body).to.be.equal(onlyResponse.body);
-      done();
+      expect(response).to.be.equal(expectedResponse);
+      expect(body).to.be.equal(expectedResponse.body);
     });
+
+    expect(promise).to.be.rejectedWith(RequestError).and.notify(done);
 
     this.clock.tick(7000); // tick the timeout
   });
 
   it('should return error if challengeId extraction fails', function(done) {
-    var onlyResponse = helper.fakeResponse({
+    var expectedResponse = helper.fakeResponse({
       statusCode: 503,
       body: helper.getFixture('js_challenge_03_12_2018_1.html')
     });
 
-    onlyResponse.body = onlyResponse.body.replace(/name="jschl_vc"/gm, '');
+    expectedResponse.body = expectedResponse.body.replace(/name="jschl_vc"/gm, '');
 
-    Request.callsFake(helper.fakeRequest({ response: onlyResponse }));
+    Request.callsFake(helper.fakeRequest({ response: expectedResponse }));
 
-    cloudscraper.get(uri, function(error, response, body) {
+    var promise = cloudscraper.get(uri, function (error, response, body) {
       // errorType 3, means parsing failed
       expect(error).to.be.an('object');
       expect(error).to.own.include({ errorType: 3 });
       expect(error.error).to.be.a('string');
       expect(error.error).to.include('I cant extract challengeId');
 
-      expect(Request).to.be.calledOnce;
-      expect(Request).to.be.calledWithExactly(helper.defaultParams);
+      expect(Request).to.be.calledOnceWithExactly(helper.defaultParams);
 
-      expect(response).to.be.equal(onlyResponse);
-      expect(body).to.be.equal(onlyResponse.body);
-      done();
+      expect(response).to.be.equal(expectedResponse);
+      expect(body).to.be.equal(expectedResponse.body);
     });
+
+    expect(promise).to.be.rejectedWith(RequestError).and.notify(done);
 
     this.clock.tick(7000); // tick the timeout
   });
 
 
   it('should return error if it was thrown by request when solving challenge', function(done) {
-    var onlyResponse = helper.fakeResponse({
+    var expectedResponse = helper.fakeResponse({
       statusCode: 503,
       body: helper.getFixture('js_challenge_21_05_2015.html')
     });
@@ -246,12 +249,12 @@ describe('Cloudscraper', function() {
 
     // Cloudflare is enabled for site. It returns a page with js challenge
     Request.onFirstCall()
-        .callsFake(helper.fakeRequest({ response: onlyResponse }));
+        .callsFake(helper.fakeRequest({ response: expectedResponse }));
 
     Request.onSecondCall()
         .callsFake(helper.fakeRequest({ error: fakeError }));
 
-    cloudscraper.get(uri, function(error) {
+    var promise = cloudscraper.get(uri, function (error) {
       // errorType 0, a connection error for example
       expect(error).to.be.an('object');
       expect(error).to.be.eql({ errorType: 0, error: fakeError });
@@ -259,8 +262,9 @@ describe('Cloudscraper', function() {
 
       expect(Request).to.be.calledTwice;
       expect(Request.firstCall).to.be.calledWithExactly(helper.defaultParams);
-      done();
     });
+
+    expect(promise).to.be.rejectedWith(RequestError).and.notify(done);
 
     // tick the timeout
     this.clock.tick(7000);
@@ -295,7 +299,7 @@ describe('Cloudscraper', function() {
     Request.onSecondCall()
         .callsFake(helper.fakeRequest({ response: secondResponse }));
 
-    cloudscraper.get(uri, function(error, response, body) {
+    var promise = cloudscraper.get(uri, function (error, response, body) {
       // errorType 1, means captcha is served
       expect(error).to.be.an('object');
       expect(error).to.be.eql({ errorType: 1 });
@@ -306,8 +310,9 @@ describe('Cloudscraper', function() {
 
       expect(response).to.be.equal(secondResponse);
       expect(body).to.be.equal(secondResponse.body);
-      done();
     });
+
+    expect(promise).to.be.rejectedWith(RequestError).and.notify(done);
 
     this.clock.tick(7000); // tick the timeout
   });
@@ -315,28 +320,28 @@ describe('Cloudscraper', function() {
   it('should return error if challenge page cookie extraction fails', function(done) {
     // Cloudflare is enabled for site.
     // It returns a redirecting page if a (session) cookie is unset.
-    var onlyResponse = helper.fakeResponse({
+    var expectedResponse = helper.fakeResponse({
       statusCode: 503,
       // The cookie extraction codes looks for the `S` variable assignment
       body: helper.getFixture('js_challenge_cookie.html').replace(/S=/gm, 'Z=')
     });
 
-    Request.callsFake(helper.fakeRequest({ response: onlyResponse }));
+    Request.callsFake(helper.fakeRequest({ response: expectedResponse }));
 
-    cloudscraper.get(uri, function(error, response, body) {
+    var promise = cloudscraper.get(uri, function (error, response, body) {
       expect(error).to.be.an('object');
       expect(error).to.be.eql({
         errorType: 3,
         error: 'I cant extract cookie generation code from page'
       });
 
-      expect(Request).to.be.calledOnce;
-      expect(Request.firstCall).to.be.calledWithExactly(helper.defaultParams);
+      expect(Request).to.be.calledOnceWithExactly(helper.defaultParams);
 
-      expect(response).to.be.equal(onlyResponse);
-      expect(body).to.be.equal(onlyResponse.body);
-      done();
+      expect(response).to.be.equal(expectedResponse);
+      expect(body).to.be.equal(expectedResponse.body);
     });
+
+    expect(promise).to.be.rejectedWith(RequestError).and.notify(done);
   });
 
   it('should throw a TypeError if callback is not a function', function(done) {
@@ -345,6 +350,15 @@ describe('Cloudscraper', function() {
     });
 
     expect(spy).to.throw(TypeError, /Expected a callback function/);
+    done();
+  });
+
+  it('should throw a TypeError if requester is not a function', function (done) {
+    var spy = sinon.spy(function () {
+      cloudscraper.get({ requester: null });
+    });
+
+    expect(spy).to.throw(TypeError, /`requester` option .*function/);
     done();
   });
 
@@ -359,12 +373,12 @@ describe('Cloudscraper', function() {
     done();
   });
 
-  it('should detect captcha in the response body\'s real encoding', function(done) {
+  it('should detect captcha in response body\'s real encoding', function (done) {
     var firstParams = helper.extendParams({
       realEncoding: 'fake-encoding'
     });
 
-    var onlyResponse = helper.fakeResponse({
+    var expectedResponse = helper.fakeResponse({
       statusCode: 503,
       body: {
         toString: function(encoding) {
@@ -377,22 +391,22 @@ describe('Cloudscraper', function() {
       }
     });
 
-    Request.callsFake(helper.fakeRequest({ response: onlyResponse }));
+    Request.callsFake(helper.fakeRequest({ response: expectedResponse }));
 
     var options = { uri: uri, encoding: 'fake-encoding' };
 
-    cloudscraper.get(options, function(error, response, body) {
+    var promise = cloudscraper.get(options, function (error, response, body) {
       // errorType 1, means captcha is served
       expect(error).to.be.an('object');
       expect(error).to.be.eql({ errorType: 1 });
 
-      expect(Request).to.be.calledOnce;
-      expect(Request.firstCall).to.be.calledWithExactly(firstParams);
+      expect(Request).to.be.calledOnceWithExactly(firstParams);
 
-      expect(response).to.be.equal(onlyResponse);
-      expect(body).to.be.equal(onlyResponse.body.toString('fake-encoding'));
-      done();
+      expect(response).to.be.equal(expectedResponse);
+      expect(body).to.be.equal(expectedResponse.body.toString('fake-encoding'));
     });
+
+    expect(promise).to.be.rejectedWith(RequestError).and.notify(done);
 
     this.clock.tick(7000); // tick the timeout
   });
@@ -402,27 +416,27 @@ describe('Cloudscraper', function() {
     var html = helper.getFixture('js_challenge_cookie.html');
     var b64 = (new Buffer('throw new Error(\'vm eval failed\');')).toString('base64');
 
-    var onlyResponse = helper.fakeResponse({
+    var expectedResponse = helper.fakeResponse({
       statusCode: 503,
       body: html.replace(/S='([^']+)'/, 'S=\'' + b64 + '\'')
     });
 
-    Request.callsFake(helper.fakeRequest({ response: onlyResponse }));
+    Request.callsFake(helper.fakeRequest({ response: expectedResponse }));
 
-    cloudscraper.get(uri, function(error, response, body) {
+    var promise = cloudscraper.get(uri, function (error, response, body) {
       // errorType 3, means parsing failed
       expect(error).to.be.an('object');
       expect(error).to.own.include({ errorType: 3 });
       expect(error.error).to.be.a('string');
       expect(error.error).to.include('Error occurred during evaluation: vm eval failed');
 
-      expect(Request).to.be.calledOnce;
-      expect(Request).to.be.calledWithExactly(helper.defaultParams);
+      expect(Request).to.be.calledOnceWithExactly(helper.defaultParams);
 
-      expect(response).to.be.equal(onlyResponse);
-      expect(body).to.be.equal(onlyResponse.body);
-      done();
+      expect(response).to.be.equal(expectedResponse);
+      expect(body).to.be.equal(expectedResponse.body);
     });
+
+    expect(promise).to.be.rejectedWith(RequestError).and.notify(done);
 
     this.clock.tick(7000); // tick the timeout
   });

--- a/test/test-rp.js
+++ b/test/test-rp.js
@@ -1,0 +1,105 @@
+'use strict';
+
+var cloudscraper = require('../index');
+var request = require('request-promise');
+var helper = require('./helper');
+
+var sinon = require('sinon');
+var expect = require('chai').expect;
+
+describe('Cloudscraper promise', function () {
+  var requestedPage = helper.getFixture('requested_page.html');
+  var uri = helper.defaultParams.uri;
+  var sandbox;
+  var Request;
+
+  beforeEach(function () {
+    helper.defaultParams.jar = request.jar();
+    sandbox = sinon.createSandbox();
+    // Prepare stubbed Request for each test
+    Request = sandbox.stub(request, 'Request');
+    // setTimeout should be properly stubbed to prevent the unit test from running too long.
+    this.clock = sinon.useFakeTimers();
+  });
+
+  afterEach(function () {
+    sandbox.restore();
+    this.clock.restore();
+  });
+
+  it('should resolve with response body', function () {
+    var expectedResponse = helper.fakeResponse({ body: requestedPage });
+    var expectedParams = helper.extendParams({ callback: undefined });
+
+    Request.callsFake(helper.fakeRequest({ response: expectedResponse }));
+
+    var promise = cloudscraper.get(uri);
+
+    return promise.then(function (body) {
+      expect(Request).to.be.calledOnceWithExactly(expectedParams);
+      expect(body).to.be.equal(requestedPage);
+    });
+  });
+
+  it('should resolve with full response', function () {
+    var expectedResponse = helper.fakeResponse({
+      statusCode: 200,
+      body: requestedPage
+    });
+
+    var expectedParams = helper.extendParams({
+      callback: undefined,
+      resolveWithFullResponse: true
+    });
+
+    // The method is implicitly GET
+    delete expectedParams.method;
+
+    Request.callsFake(helper.fakeRequest({ response: expectedResponse }));
+
+    var promise = cloudscraper({
+      uri: uri,
+      resolveWithFullResponse: true
+    });
+
+    return promise.then(function (response) {
+      expect(Request).to.be.calledOnceWithExactly(expectedParams);
+
+      expect(response).to.be.equal(expectedResponse);
+      expect(response.body).to.be.equal(requestedPage);
+    });
+  });
+
+  // The helper calls the fake request callback synchronously. This results
+  // in the promise being rejected before we catch it in the test.
+  // This can be noticeable if we return the promise instead of calling done.
+  it('should define catch', function (done) {
+    var expectedResponse = helper.fakeResponse({ error: new Error('fake') });
+
+    Request.callsFake(helper.fakeRequest({ response: expectedResponse }));
+
+    var caught = false;
+    var promise = cloudscraper(uri);
+
+    promise.catch(function () {
+      caught = true;
+    }).then(function () {
+      if (caught) done();
+    });
+  });
+
+  it('should define finally', function (done) {
+    var expectedResponse = helper.fakeResponse({ error: new Error('fake') });
+
+    Request.callsFake(helper.fakeRequest({ response: expectedResponse }));
+
+    var caught = false;
+    var promise = cloudscraper(uri);
+
+    promise.then(function () {
+      caught = true;
+    }).finally(function () {
+      if (!caught) done();
+    });
+  });
+});


### PR DESCRIPTION
This fixes #93 promise-support and adds tests.

100% code coverage
The tests should serve as the primary documentation for this PR.
Everything is green!

Closes #79 

<strike>There is a major inconsistency between the callback errors and promise rejection errors. 
Essentially, the worst case scenario to get the original error that was thrown:</strike>
```js
cloudscraper.get(uri).catch(error => {
  // error.cause would be an error created by cloudscraper
  console.log(error.cause);
  // The original error
  console.log(error.cause.error);
  // The error type as defined by cloudscraper
  console.log(error.cause.errorType);
});
```
<strike>
There probably is an issue with `request-promise`'s StatusCodeError construction as well.
Other than that everything is green with 100% code coverage.</strike>