### PR TITLE
Parse the timeout from challenge page

### DIFF
--- a/test/helper.js
+++ b/test/helper.js
@@ -31,6 +31,7 @@ var helper = {
       realEncoding: 'utf8',
       followAllRedirects: true,
       cloudflareTimeout: 1,
+      cloudflareMaxTimeout: 30000,
       challengesToSolve: 3,
       decodeEmails: false
     };

--- a/test/test-errors.js
+++ b/test/test-errors.js
@@ -411,14 +411,14 @@ describe('Cloudscraper', function () {
     done();
   });
 
-  it('should throw a TypeError if cloudflareTimeout is not a number', function (done) {
+  it('should throw a TypeError if cloudflareMaxTimeout is not a number', function (done) {
     var spy = sinon.spy(function () {
-      var options = { uri: uri, cloudflareTimeout: 'abc' };
+      var options = { uri: uri, cloudflareMaxTimeout: 'abc' };
 
       cloudscraper.get(options, function () {});
     });
 
-    expect(spy).to.throw(TypeError, /`cloudflareTimeout` option .*number/);
+    expect(spy).to.throw(TypeError, /`cloudflareMaxTimeout` option .*number/);
     done();
   });
 


### PR DESCRIPTION
* Removes `cloudflareTimeout` from defaultParams but it still can be used to override the parsed timeout.
* Adds a `cloudflareMaxTimeout` option (see code comment for usage).
* The validation and test for `cloudflareTimeout` have been re-purposed to check `cloudflareMaxTimeout`.

*Ignores timeout related parsing error if `cloudflareTimeout` was manually specified*