### PR TITLE
(WIP) Add Accept-Encoding header

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,11 +38,14 @@ function defaults (params) {
     requester: requestModule,
     // Cookies should be enabled
     jar: requestModule.jar(),
+    // Support for gzip encoded responses
+    gzip: true,
     headers: {
       'Connection': 'keep-alive',
       'User-Agent': DEFAULT_USER_AGENT,
       'Cache-Control': 'private',
       'Accept': 'application/xml,application/xhtml+xml,text/html;q=0.9, text/plain;q=0.8,image/png,*/*;q=0.5',
+      'Accept-Encoding': 'gzip, deflate',
       'Accept-Language': 'en-US,en;q=0.9'
     },
     // Cloudflare requires a delay of 4 seconds, so wait for at least 5.

--- a/test/helper.js
+++ b/test/helper.js
@@ -19,11 +19,13 @@ var helper = {
       requester: sinon.match.func,
       jar: request.jar(),
       uri: helper.resolve('/test'),
+      gzip: true,
       headers: {
         'Connection': 'keep-alive',
         'User-Agent': sinon.match.string,
         'Cache-Control': 'private',
         'Accept': 'application/xml,application/xhtml+xml,text/html;q=0.9, text/plain;q=0.8,image/png,*/*;q=0.5',
+        'Accept-Encoding': 'gzip, deflate',
         'Accept-Language': 'en-US,en;q=0.9'
       },
       method: 'GET',


### PR DESCRIPTION
Builds on #174 by adding the 'Accept-Encoding' header for domains that require it. Supports gzipped encoded responses by default and prevents CAPTCHA.