### PR TITLE
(tls): make ciphers similar to chrome

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ function defaults (params) {
     gzip: true,
     agentOptions: {
       // Removes a few problematic TLSv1.0 ciphers to avoid CAPTCHA
-      ciphers: crypto.constants.defaultCipherList + ':!ECDHE+SHA:!AES128-SHA'
+      ciphers: crypto.constants.defaultCipherList + ':!ECDHE+SHA:!AES128-SHA:!AESCCM:!DHE:!ARIA'
     }
   };
 


### PR DESCRIPTION
As titled, this change makes the cipher list very similar to what chromium sends.

* Cloudflare doesn't support DHE, Chrome doesn't send it
* Chrome doesn't send ARIA or AESCCM

After comparing the cipher list with the change, these were the only differences according to https://www.howsmyssl.com/a/check

Besides TLS_RSA_WITH_AES <- some differences there, see the lists.
(We already omit some SHA-1 via `!ECDHE+SHA:!AES128-SHA`)

Node sends:
   * `TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256`
   * `TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384`
   * `TLS_EMPTY_RENEGOTIATION_INFO_SCSV`

Chrome sends:
   * `TLS_GREASE_IS_THE_WORD_8A`

The rest was the same on my system:
* ***Node.js v12.7.0, OpenSSL v1.1.1c, Linux kali 4.19.0-kali5-amd64 `#1` SMP Debian 4.19.37-5kali1 (2019-06-20) x86_64 GNU/Linux, AMD E2-9000e RADEON R2, 4 COMPUTE CORES 2C+2G***
* ***Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.142 Safari/537.36*** (The default, statically linked boringssl) (Prebuilt branded Google Chrome)

Notes:
   - *This does not affect whether or not I receive a CAPTCHA ***on*** my system.*
   - *This may not affect whether or not users receive a CAPTCHA on ***their*** system.*
   - *This is likely to improve the TLS situation in general and possibly prevent CAPTCHA.*
   - *This may affect compatibility with non-Cloudflare sites but ***not*** Cloudflare sites.*

<details><summary>Ciphers omitted due to change</summary>

```js
[
  'TLS_DHE_RSA_WITH_AES_128_GCM_SHA256',
  'TLS_DHE_RSA_WITH_AES_128_CBC_SHA256',
  'TLS_DHE_RSA_WITH_AES_256_CBC_SHA256',
  'TLS_DHE_DSS_WITH_AES_256_GCM_SHA384',
  'TLS_DHE_RSA_WITH_AES_256_GCM_SHA384',
  'TLS_DHE_RSA_WITH_CHACHA20_POLY1305',
  'TLS_ECDHE_ECDSA_WITH_AES_256_CCM_8',
  'TLS_ECDHE_ECDSA_WITH_AES_256_CCM',
  'TLS_DHE_RSA_WITH_AES_256_CCM_8',
  'TLS_DHE_RSA_WITH_AES_256_CCM',
  'TLS_ECDHE_ECDSA_WITH_ARIA_256_GCM_SHA384',
  'TLS_ECDHE_RSA_WITH_ARIA_256_GCM_SHA384',
  'TLS_DHE_DSS_WITH_ARIA_256_GCM_SHA384',
  'TLS_DHE_RSA_WITH_ARIA_256_GCM_SHA384',
  'TLS_DHE_DSS_WITH_AES_128_GCM_SHA256',
  'TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8',
  'TLS_ECDHE_ECDSA_WITH_AES_128_CCM',
  'TLS_DHE_RSA_WITH_AES_128_CCM_8',
  'TLS_DHE_RSA_WITH_AES_128_CCM',
  'TLS_ECDHE_ECDSA_WITH_ARIA_128_GCM_SHA256',
  'TLS_ECDHE_RSA_WITH_ARIA_128_GCM_SHA256',
  'TLS_DHE_DSS_WITH_ARIA_128_GCM_SHA256',
  'TLS_DHE_RSA_WITH_ARIA_128_GCM_SHA256',
  'TLS_DHE_DSS_WITH_AES_256_CBC_SHA256',
  'TLS_DHE_DSS_WITH_AES_128_CBC_SHA256',
  'TLS_DHE_RSA_WITH_AES_256_CBC_SHA',
  'TLS_DHE_DSS_WITH_AES_256_CBC_SHA',
  'TLS_DHE_RSA_WITH_AES_128_CBC_SHA',
  'TLS_DHE_DSS_WITH_AES_128_CBC_SHA',
  'TLS_RSA_WITH_AES_256_CCM_8',
  'TLS_RSA_WITH_AES_256_CCM',
  'TLS_RSA_WITH_ARIA_256_GCM_SHA384',
  'TLS_RSA_WITH_AES_128_CCM_8',
  'TLS_RSA_WITH_AES_128_CCM',
  'TLS_RSA_WITH_ARIA_128_GCM_SHA256'
]
```
</details>

<details><summary>Chrome v75 ciphers</summary>

```js
[
    'TLS_GREASE_IS_THE_WORD_0A',
    'TLS_AES_128_GCM_SHA256',
    'TLS_AES_256_GCM_SHA384',
    'TLS_CHACHA20_POLY1305_SHA256',
    'TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256',
    'TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256',
    'TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384',
    'TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384',
    'TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256',
    'TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256',
    'TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA',
    'TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA',
    'TLS_RSA_WITH_AES_128_GCM_SHA256',
    'TLS_RSA_WITH_AES_256_GCM_SHA384',
    'TLS_RSA_WITH_AES_128_CBC_SHA',
    'TLS_RSA_WITH_AES_256_CBC_SHA',
    'TLS_RSA_WITH_3DES_EDE_CBC_SHA'
  ]
```
</details>

<details><summary>Node.js v12.7.0 (This PR)</summary>

```js
[
    'TLS_AES_256_GCM_SHA384',
    'TLS_CHACHA20_POLY1305_SHA256',
    'TLS_AES_128_GCM_SHA256',
    'TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256',
    'TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256',
    'TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384',
    'TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384',
    'TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256',
    'TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384',
    'TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256',
    'TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256',
    'TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384',
    'TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256',
    'TLS_RSA_WITH_AES_256_GCM_SHA384',
    'TLS_RSA_WITH_AES_128_GCM_SHA256',
    'TLS_RSA_WITH_AES_256_CBC_SHA256',
    'TLS_RSA_WITH_AES_128_CBC_SHA256',
    'TLS_RSA_WITH_AES_256_CBC_SHA',
    'TLS_EMPTY_RENEGOTIATION_INFO_SCSV'
  ]
```
</details>
