### PR TITLE
Clean up request error and test error output

### DIFF
--- a/errors.js
+++ b/errors.js
@@ -91,6 +91,14 @@ Object.assign(module.exports, original, {
   CloudflareError: CloudflareError
 });
 
+const desc = { configurable: true, writable: true, enumerable: false };
+const descriptors = {
+  error: desc,
+  cause: desc,
+  response: desc,
+  options: desc
+};
+
 function create (name, errorType, customize) {
   function CustomError (cause, options, response) {
     // This prevents nasty things e.g. `error.cause.error` and
@@ -98,6 +106,9 @@ function create (name, errorType, customize) {
     if (cause instanceof OriginalError) {
       return cause;
     }
+
+    // Cleanup error output
+    Object.defineProperties(this, descriptors);
 
     OriginalError.apply(this, arguments);
 

--- a/test/test-captcha.js
+++ b/test/test-captcha.js
@@ -61,9 +61,8 @@ describe('Cloudscraper', function () {
       expect(error.error).to.be.an('error');
       expect(error).to.have.property('errorType', 1);
       expect(error.message).to.include('Falsy error');
+      expect(promise).to.be.rejectedWith(errors.CaptchaError).and.notify(done);
     });
-
-    expect(promise).to.be.rejectedWith(errors.CaptchaError).and.notify(done);
   });
 
   for (let stage = 0; stage < 4; stage++) {
@@ -158,6 +157,7 @@ describe('Cloudscraper', function () {
             expect(Request.secondCall).to.be.calledWithExactly(secondParams);
 
             expect(body).to.be.equal(requestedPage);
+            expect(promise).to.eventually.equal(requestedPage).and.notify(done);
             break;
           case 1:
           case 3:
@@ -165,20 +165,10 @@ describe('Cloudscraper', function () {
             expect(error.error).to.be.an('error');
             expect(error).to.have.property('errorType', 1);
             expect(error.message).to.include(expectedError.message);
+            expect(promise).to.be.rejectedWith(errors.CaptchaError).and.notify(done);
             break;
         }
       });
-
-      switch (stage) {
-        case 0:
-        case 2:
-          expect(promise).to.eventually.equal(requestedPage).and.notify(done);
-          break;
-        case 1:
-        case 3:
-          expect(promise).to.be.rejectedWith(errors.CaptchaError).and.notify(done);
-          break;
-      }
     });
   }
 });

--- a/test/test-errors.js
+++ b/test/test-errors.js
@@ -52,9 +52,8 @@ describe('Cloudscraper', function () {
       expect(error).to.have.property('errorType', 0);
 
       expect(Request).to.be.calledOnceWithExactly(helper.defaultParams);
+      expect(promise).to.be.rejectedWith(errors.RequestError).and.notify(done);
     });
-
-    expect(promise).to.be.rejectedWith(errors.RequestError).and.notify(done);
   });
 
   it('should return error if cloudflare response is empty', function (done) {
@@ -72,9 +71,8 @@ describe('Cloudscraper', function () {
       expect(Request).to.be.calledOnceWithExactly(helper.defaultParams);
 
       expect(error.response.body).to.be.eql(Buffer.alloc(0));
+      expect(promise).to.be.rejectedWith(errors.CloudflareError).and.notify(done);
     });
-
-    expect(promise).to.be.rejectedWith(errors.CloudflareError).and.notify(done);
   });
 
   it('should return error if captcha is served by cloudflare', function (done) {
@@ -89,9 +87,8 @@ describe('Cloudscraper', function () {
       expect(error).to.have.property('errorType', 1);
 
       expect(Request).to.be.calledOnceWithExactly(helper.defaultParams);
+      expect(promise).to.be.rejectedWith(errors.CaptchaError).and.notify(done);
     });
-
-    expect(promise).to.be.rejectedWith(errors.CaptchaError).and.notify(done);
   });
 
   it('should return error if cloudflare returned some inner error', function (done) {
@@ -111,9 +108,8 @@ describe('Cloudscraper', function () {
       expect(error).to.have.property('errorType', 2);
 
       expect(Request).to.be.calledOnceWithExactly(helper.defaultParams);
+      expect(promise).to.be.rejectedWith(errors.CloudflareError).and.notify(done);
     });
-
-    expect(promise).to.be.rejectedWith(errors.CloudflareError).and.notify(done);
   });
 
   it('should add a description to 5xx range cloudflare errors', function (done) {
@@ -131,9 +127,8 @@ describe('Cloudscraper', function () {
       expect(error).to.have.property('errorType', 2);
 
       expect(Request).to.be.calledOnceWithExactly(helper.defaultParams);
+      expect(promise).to.be.rejectedWith(errors.CloudflareError).and.notify(done);
     });
-
-    expect(promise).to.be.rejectedWith(errors.CloudflareError).and.notify(done);
   });
 
   it('should not error if error description is unavailable', function (done) {
@@ -151,9 +146,8 @@ describe('Cloudscraper', function () {
       expect(error).to.have.property('errorType', 2);
 
       expect(Request).to.be.calledOnceWithExactly(helper.defaultParams);
+      expect(promise).to.be.rejectedWith(errors.CloudflareError).and.notify(done);
     });
-
-    expect(promise).to.be.rejectedWith(errors.CloudflareError).and.notify(done);
   });
 
   it('should return error if cf presented more than 3 challenges in a row', function (done) {
@@ -187,9 +181,9 @@ describe('Cloudscraper', function () {
         expectedParams.challengesToSolve -= 1;
         expect(Request.getCall(i)).to.be.calledWithExactly(expectedParams);
       }
-    });
 
-    expect(promise).to.be.rejectedWith(errors.CloudflareError).and.notify(done);
+      expect(promise).to.be.rejectedWith(errors.CloudflareError).and.notify(done);
+    });
   });
 
   it('should return error if body is undefined', function (done) {
@@ -209,9 +203,8 @@ describe('Cloudscraper', function () {
 
       expect(error.response.body).to.be.equal(undefined);
       expect(Request).to.be.calledOnceWithExactly(expectedParams);
+      expect(promise).to.be.rejectedWith(errors.RequestError).and.notify(done);
     });
-
-    expect(promise).to.be.rejectedWith(errors.RequestError).and.notify(done);
   });
 
   it('should return error if challenge page failed to be parsed', function (done) {
@@ -225,9 +218,8 @@ describe('Cloudscraper', function () {
       expect(error).to.have.property('errorType', 3);
 
       expect(Request).to.be.calledOnceWithExactly(helper.defaultParams);
+      expect(promise).to.be.rejectedWith(errors.ParserError).and.notify(done);
     });
-
-    expect(promise).to.be.rejectedWith(errors.ParserError).and.notify(done);
   });
 
   it('should return error if js challenge has error during evaluation', function (done) {
@@ -245,9 +237,8 @@ describe('Cloudscraper', function () {
       expect(error.message).to.include('Challenge evaluation failed');
 
       expect(Request).to.be.calledOnceWithExactly(helper.defaultParams);
+      expect(promise).to.be.rejectedWith(errors.ParserError).and.notify(done);
     });
-
-    expect(promise).to.be.rejectedWith(errors.ParserError).and.notify(done);
   });
 
   it('should return error if pass extraction fails', function (done) {
@@ -263,9 +254,8 @@ describe('Cloudscraper', function () {
       expect(error).to.have.property('errorType', 3);
 
       expect(Request).to.be.calledOnceWithExactly(helper.defaultParams);
+      expect(promise).to.be.rejectedWith(errors.ParserError).and.notify(done);
     });
-
-    expect(promise).to.be.rejectedWith(errors.ParserError).and.notify(done);
   });
 
   it('should return error if challengeId extraction fails', function (done) {
@@ -281,9 +271,8 @@ describe('Cloudscraper', function () {
       expect(error).to.have.property('errorType', 3);
 
       expect(Request).to.be.calledOnceWithExactly(helper.defaultParams);
+      expect(promise).to.be.rejectedWith(errors.ParserError).and.notify(done);
     });
-
-    expect(promise).to.be.rejectedWith(errors.ParserError).and.notify(done);
   });
 
   it('should return error if challenge answer is not a number', function (done) {
@@ -300,9 +289,8 @@ describe('Cloudscraper', function () {
       expect(error).to.have.property('errorType', 3);
 
       expect(Request).to.be.calledOnceWithExactly(helper.defaultParams);
+      expect(promise).to.be.rejectedWith(errors.ParserError).and.notify(done);
     });
-
-    expect(promise).to.be.rejectedWith(errors.ParserError).and.notify(done);
   });
 
   it('should return error if it was thrown by request when solving challenge', function (done) {
@@ -322,9 +310,8 @@ describe('Cloudscraper', function () {
 
       expect(Request).to.be.calledTwice;
       expect(Request.firstCall).to.be.calledWithExactly(helper.defaultParams);
+      expect(promise).to.be.rejectedWith(errors.RequestError).and.notify(done);
     });
-
-    expect(promise).to.be.rejectedWith(errors.RequestError).and.notify(done);
   });
 
   it('should properly handle a case when after a challenge another one is returned', function (done) {
@@ -357,9 +344,8 @@ describe('Cloudscraper', function () {
       expect(Request).to.be.calledTwice;
       expect(Request.firstCall).to.be.calledWithExactly(helper.defaultParams);
       expect(Request.secondCall).to.be.calledWithExactly(expectedParams);
+      expect(promise).to.be.rejectedWith(errors.CaptchaError).and.notify(done);
     });
-
-    expect(promise).to.be.rejectedWith(errors.CaptchaError).and.notify(done);
   });
 
   it('should return error if challenge page cookie extraction fails', function (done) {
@@ -376,9 +362,8 @@ describe('Cloudscraper', function () {
       expect(error).to.have.property('errorType', 3);
 
       expect(Request).to.be.calledOnceWithExactly(helper.defaultParams);
+      expect(promise).to.be.rejectedWith(errors.ParserError).and.notify(done);
     });
-
-    expect(promise).to.be.rejectedWith(errors.ParserError).and.notify(done);
   });
 
   it('should throw a TypeError if callback is not a function', function (done) {
@@ -439,9 +424,8 @@ describe('Cloudscraper', function () {
       expect(error.message).to.include('vm eval failed');
 
       expect(Request).to.be.calledOnceWithExactly(helper.defaultParams);
+      expect(promise).to.be.rejectedWith(errors.ParserError).and.notify(done);
     });
-
-    expect(promise).to.be.rejectedWith(errors.ParserError).and.notify(done);
   });
 
   it('should not error if Error.captureStackTrace is undefined', function () {

--- a/test/test-index.js
+++ b/test/test-index.js
@@ -56,9 +56,8 @@ describe('Cloudscraper', function () {
       expect(error).to.be.null;
       expect(Request).to.be.calledOnceWithExactly(expectedParams);
       expect(body).to.be.equal(expectedBody);
+      expect(promise).to.eventually.equal(expectedBody).and.notify(done);
     });
-
-    expect(promise).to.eventually.equal(expectedBody).and.notify(done);
   });
 
   it('should return json', function (done) {
@@ -75,9 +74,8 @@ describe('Cloudscraper', function () {
       expect(error).to.be.null;
       expect(Request).to.be.calledOnceWithExactly(expectedParams);
       expect(body).to.be.eql(expectedBody);
+      expect(promise).to.eventually.eql(expectedBody).and.notify(done);
     });
-
-    expect(promise).to.eventually.eql(expectedBody).and.notify(done);
   });
 
   it('should return requested data, if cloudflare is disabled for page', function (done) {
@@ -93,9 +91,8 @@ describe('Cloudscraper', function () {
       expect(error).to.be.null;
       expect(Request).to.be.calledOnceWithExactly(expectedParams);
       expect(body).to.be.equal('xyz');
+      expect(promise).to.eventually.equal('xyz').and.notify(done);
     });
-
-    expect(promise).to.eventually.equal('xyz').and.notify(done);
   });
 
   it('should return requested page, if cloudflare is disabled for page', function (done) {
@@ -107,9 +104,8 @@ describe('Cloudscraper', function () {
       expect(error).to.be.null;
       expect(Request).to.be.calledOnceWithExactly(helper.defaultParams);
       expect(body).to.be.equal(requestedPage);
+      expect(promise).to.eventually.equal(requestedPage).and.notify(done);
     });
-
-    expect(promise).to.eventually.equal(requestedPage).and.notify(done);
   });
 
   it('should not trigger any error if recaptcha is present in page not protected by CF', function (done) {
@@ -123,9 +119,8 @@ describe('Cloudscraper', function () {
       expect(error).to.be.null;
       expect(Request).to.be.calledOnceWithExactly(helper.defaultParams);
       expect(body).to.be.equal(expectedBody);
+      expect(promise).to.eventually.equal(expectedBody).and.notify(done);
     });
-
-    expect(promise).to.eventually.equal(expectedBody).and.notify(done);
   });
 
   it('should resolve challenge (version as on 21.05.2015) and then return page', function (done) {
@@ -160,9 +155,8 @@ describe('Cloudscraper', function () {
       expect(Request.secondCall).to.be.calledWithExactly(expectedParams);
 
       expect(body).to.be.equal(requestedPage);
+      expect(promise).to.eventually.equal(requestedPage).and.notify(done);
     });
-
-    expect(promise).to.eventually.equal(requestedPage).and.notify(done);
   });
 
   it('should resolve challenge (version as on 09.06.2016) and then return page', function (done) {
@@ -198,9 +192,8 @@ describe('Cloudscraper', function () {
       expect(Request.secondCall).to.be.calledWithExactly(expectedParams);
 
       expect(body).to.be.equal(requestedPage);
+      expect(promise).to.eventually.equal(requestedPage).and.notify(done);
     });
-
-    expect(promise).to.eventually.equal(requestedPage).and.notify(done);
   });
 
   it('should resolve challenge (version as on 13.03.2019) and then return page', function (done) {
@@ -236,9 +229,8 @@ describe('Cloudscraper', function () {
       expect(Request.secondCall).to.be.calledWithExactly(expectedParams);
 
       expect(body).to.be.equal(requestedPage);
+      expect(promise).to.eventually.equal(requestedPage).and.notify(done);
     });
-
-    expect(promise).to.eventually.equal(requestedPage).and.notify(done);
   });
 
   it('should resolve challenge (version as on 21.03.2019) and then return page', function (done) {
@@ -273,9 +265,8 @@ describe('Cloudscraper', function () {
       expect(Request.secondCall).to.be.calledWithExactly(expectedParams);
 
       expect(body).to.be.equal(requestedPage);
+      expect(promise).to.eventually.equal(requestedPage).and.notify(done);
     });
-
-    expect(promise).to.eventually.equal(requestedPage).and.notify(done);
   });
 
   it('should resolve challenge (version as on 10.04.2019) and then return page', function (done) {
@@ -309,9 +300,8 @@ describe('Cloudscraper', function () {
       expect(Request.secondCall).to.be.calledWithExactly(expectedParams);
 
       expect(body).to.be.equal(requestedPage);
+      expect(promise).to.eventually.equal(requestedPage).and.notify(done);
     });
-
-    expect(promise).to.eventually.equal(requestedPage).and.notify(done);
   });
 
   it('should resolve 2 consequent challenges', function (done) {
@@ -375,9 +365,8 @@ describe('Cloudscraper', function () {
       expect(Request.thirdCall).to.be.calledWithExactly(thirdParams);
 
       expect(body).to.be.equal(requestedPage);
+      expect(promise).to.eventually.haveOwnProperty('body', requestedPage).and.notify(done);
     });
-
-    expect(promise).to.eventually.haveOwnProperty('body', requestedPage).and.notify(done);
   });
 
   it('should make post request with formData', function (done) {
@@ -398,9 +387,8 @@ describe('Cloudscraper', function () {
       expect(error).to.be.null;
       expect(Request).to.be.calledOnceWithExactly(expectedParams);
       expect(body).to.be.equal(requestedPage);
+      expect(promise).to.eventually.equal(requestedPage).and.notify(done);
     });
-
-    expect(promise).to.eventually.equal(requestedPage).and.notify(done);
   });
 
   it('should make delete request', function (done) {
@@ -414,9 +402,8 @@ describe('Cloudscraper', function () {
       expect(error).to.be.null;
       expect(Request).to.be.calledOnceWithExactly(expectedParams);
       expect(body).to.be.equal(requestedPage);
+      expect(promise).to.eventually.equal(requestedPage).and.notify(done);
     });
-
-    expect(promise).to.eventually.equal(requestedPage).and.notify(done);
   });
 
   it('should return raw data when encoding is null', function (done) {
@@ -433,9 +420,8 @@ describe('Cloudscraper', function () {
       expect(error).to.be.null;
       expect(Request).to.be.calledOnceWithExactly(expectedParams);
       expect(body).to.be.eql(expectedBody);
+      expect(promise).to.eventually.eql(expectedBody).and.notify(done);
     });
-
-    expect(promise).to.eventually.eql(expectedBody).and.notify(done);
   });
 
   it('should set the given cookie and then return page', function (done) {
@@ -461,9 +447,8 @@ describe('Cloudscraper', function () {
       expect(Request.secondCall).to.be.calledWithExactly(expectedParams);
 
       expect(body).to.be.equal(requestedPage);
+      expect(promise).to.eventually.equal(requestedPage).and.notify(done);
     });
-
-    expect(promise).to.eventually.equal(requestedPage).and.notify(done);
   });
 
   it('should not use proxy\'s uri', function (done) {
@@ -512,9 +497,8 @@ describe('Cloudscraper', function () {
       expect(Request.secondCall).to.be.calledWithExactly(secondParams);
 
       expect(body).to.be.equal(requestedPage);
+      expect(promise).to.eventually.equal(requestedPage).and.notify(done);
     });
-
-    expect(promise).to.eventually.equal(requestedPage).and.notify(done);
   });
 
   it('should reuse the provided cookie jar', function (done) {
@@ -592,9 +576,8 @@ describe('Cloudscraper', function () {
       expect(Request.firstCall).to.be.calledWithExactly(firstParams);
 
       expect(body).to.include('cloudscraper@example-site.dev');
+      expect(promise).to.eventually.include('cloudscraper@example-site.dev').and.notify(done);
     });
-
-    expect(promise).to.eventually.include('cloudscraper@example-site.dev').and.notify(done);
   });
 
   it('should not error when using the baseUrl option', function (done) {
@@ -621,9 +604,8 @@ describe('Cloudscraper', function () {
       expect(Request.secondCall.args[0]).to.not.have.property('baseUrl');
 
       expect(body).to.be.equal(requestedPage);
+      expect(promise).to.eventually.equal(requestedPage).and.notify(done);
     });
-
-    expect(promise).to.eventually.equal(requestedPage).and.notify(done);
   });
 
   it('should use the provided cloudflare timeout', function (done) {
@@ -647,9 +629,8 @@ describe('Cloudscraper', function () {
       const elapsed = Date.now() - start;
       // Aiming to be within ~450ms of specified timeout
       expect(elapsed >= 50 && elapsed <= 500).to.be.ok;
+      expect(promise).to.eventually.equal(requestedPage).and.notify(done);
     });
-
-    expect(promise).to.eventually.equal(requestedPage).and.notify(done);
   });
 
   it('sandbox.document.getElementById should not error', function (done) {
@@ -668,8 +649,7 @@ describe('Cloudscraper', function () {
     const promise = cloudscraper.get(uri, function (error, response, body) {
       expect(error).to.be.null;
       expect(Request).to.be.calledTwice;
+      expect(promise).to.eventually.equal(requestedPage).and.notify(done);
     });
-
-    expect(promise).to.eventually.equal(requestedPage).and.notify(done);
   });
 });


### PR DESCRIPTION
A much needed adjustment.

This fixes an issue with asynchronous tests causing other tests to bug out when they fail and removes the difficulty in debugging failed tests.