### PR TITLE
Optimize header checks

### DIFF
--- a/index.js
+++ b/index.js
@@ -192,7 +192,7 @@ function onCloudflareResponse (options, response, body) {
   const stringBody = body.toString('utf8');
 
   try {
-    validate(options, response, stringBody);
+    validateResponse(options, response, stringBody);
   } catch (error) {
     if (error instanceof CaptchaError && typeof options.onCaptcha === 'function') {
       // Give users a chance to solve the reCAPTCHA via services such as anti-captcha.com
@@ -224,7 +224,7 @@ function onCloudflareResponse (options, response, body) {
   onRequestComplete(options, response, body);
 }
 
-function validate (options, response, body) {
+function validateResponse (options, response, body) {
   // Finding captcha
   if (body.indexOf('why_captcha') !== -1 || /cdn-cgi\/l\/chk_captcha/i.test(body)) {
     // Convenience boolean

--- a/index.js
+++ b/index.js
@@ -410,7 +410,7 @@ function onCaptcha (options, response, body) {
       return callback(new CaptchaError(error, options, response));
     }
 
-    onSubmitCaptcha(options, response, body);
+    onSubmitCaptcha(options, response);
   };
 
   // This seems like an okay-ish API (fewer arguments to the handler)

--- a/lib/headers.js
+++ b/lib/headers.js
@@ -3,10 +3,12 @@
 const chromeData = require('./browsers').chrome;
 const useBrotli = require('./brotli').isAvailable;
 
-module.exports = function getHeaders (defaults) {
+module.exports = { getDefaultHeaders, caseless };
+
+function getDefaultHeaders (defaults) {
   const headers = getChromeHeaders(random(chromeData));
   return Object.assign({}, defaults, headers);
-};
+}
 
 function random (arr) {
   return arr[Math.floor(Math.random() * arr.length)];
@@ -23,4 +25,14 @@ function getChromeHeaders (options) {
   }
 
   return headers;
+}
+
+function caseless (headers) {
+  const result = {};
+
+  Object.keys(headers).forEach(key => {
+    result[key.toLowerCase()] = headers[key];
+  });
+
+  return result;
 }

--- a/test/test-headers.js
+++ b/test/test-headers.js
@@ -2,21 +2,28 @@
 /* eslint-env node, mocha */
 'use strict';
 
-const getHeaders = require('../lib/headers');
-
 const sinon  = require('sinon');
 const expect = require('chai').expect;
 
 describe('Headers (lib)', function () {
+  const { getDefaultHeaders, caseless } = require('../lib/headers');
   const browsers = require('../lib/browsers');
 
-  it('default export should be a function', function () {
-    expect(getHeaders).to.be.a('function');
+  it('should export getDefaultHeaders function', function () {
+    expect(getDefaultHeaders).to.be.a('function');
   });
 
-  it('should always return an object with user agent', function () {
+  it('should export caseless function', function () {
+    expect(caseless).to.be.a('function');
+  });
+
+  it('caseless should return an object with lowercase keys', function () {
+    sinon.assert.match(caseless({ AbC: 'foobar' }), { abc: 'foobar' });
+  });
+
+  it('getDefaultHeaders should always return an object with user agent', function () {
     for (let i = 0; i < 100; i++) {
-      sinon.assert.match(getHeaders(), { 'User-Agent': sinon.match.string });
+      sinon.assert.match(getDefaultHeaders(), { 'User-Agent': sinon.match.string });
     }
 
     browsers.chrome.forEach(function (options) {
@@ -30,15 +37,15 @@ describe('Headers (lib)', function () {
     });
   });
 
-  it('should always retain insertion order', function () {
+  it('getDefaultHeaders should always retain insertion order', function () {
     for (let keys, i = 0; i < 100; i++) {
-      keys = Object.keys(getHeaders({ Host: 'foobar' }));
+      keys = Object.keys(getDefaultHeaders({ Host: 'foobar' }));
       expect(keys[0]).to.equal('Host');
       expect(keys[1]).to.equal('Connection');
     }
 
     for (let keys, i = 0; i < 100; i++) {
-      keys = Object.keys(getHeaders({ Host: 'foobar', 'N/A': null }));
+      keys = Object.keys(getDefaultHeaders({ Host: 'foobar', 'N/A': null }));
       expect(keys[0]).to.equal('Host');
       expect(keys[1]).to.equal('N/A');
       expect(keys[2]).to.equal('Connection');


### PR DESCRIPTION
Perks:
* Remove the indirect dependency on `caseless`.
* Iterate over the header keys only once.
* Call `toLowerCase` for each key only once.

<details><summary>Rationale</summary>

Cloudscraper currently checks a few different headers using [caseless](https://npmjs.org/package/caseless).

https://github.com/codemanki/cloudscraper/blob/0d86d22e2ab2627414501230c3c1f7ded2ff4efe/index.js#L157-L158
https://github.com/codemanki/cloudscraper/blob/0d86d22e2ab2627414501230c3c1f7ded2ff4efe/index.js#L166

The following code is used for each `response.caseless.get` method call:
https://github.com/request/caseless/blob/98079105e15e04308d1f3becc3e8efab8ddd7f0e/index.js#L27-L36
![github com_request_caseless_blob_98079105e15e04308d1f3becc3e8efab8ddd7f0e_index js (1)](https://user-images.githubusercontent.com/34285059/63380110-5673b100-c385-11e9-9dab-66d79b904ede.png)

It's iterating over all the keys, calling `toLowerCase` and then comparing the result each time we check a header. This is inefficient, especially when the headers that we're checking for tend to be the last in the list.

i.e.
```
  HTTP/1.1 503 Service Temporarily Unavailable
  Date: Tue, 20 Aug 2019 20:06:29 GMT
  Content-Type: text/html; charset=UTF-8
  Connection: close
  X-Frame-Options: SAMEORIGIN
  Set-Cookie: __cfduid=d0ae8363c368eb644584c1fb3ca1424f51566331589; expires=Wed, 19-Aug-20 20:06:29 GMT; path=/; domain=redacted; HttpOnly
  Cache-Control: no-cache
  Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
  Vary: Accept-Encoding
  Server: cloudflare
  CF-RAY: 5096fcf2be1ed31c-ATL
```

There are other optimizations we can make to Cloudscraper that involve checking additional headers and would cause even a greater performance penalty if left unchanged.
</details>