### PR TITLE
Switched brotli to optional dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,9 @@
     "sinon-chai": "^3.3.0"
   },
   "peerDependencies": {
-    "request": "^2.88.0",
+    "request": "^2.88.0"
+  },
+  "optionalDependencies": {
     "brotli": "^1.3.2"
   }
 }


### PR DESCRIPTION
Since brotli is not required it should be an optional dependency, I think. :)