### PR TITLE
Fix brotli compressed JSON responses

### DIFF
--- a/lib/brotli.js
+++ b/lib/brotli.js
@@ -4,17 +4,19 @@ const zlib = require('zlib');
 
 const brotli = module.exports;
 // Convenience boolean used to check for brotli support
-brotli.isAvailable = true;
+brotli.isAvailable = false;
 // Exported for tests
 brotli.optional = optional;
 
 // Check for node's built-in brotli support
-if (typeof zlib.brotliDecompress === 'function') {
+if (typeof zlib.brotliDecompressSync === 'function') {
   brotli.decompress = function (buf) {
     return zlib.brotliDecompressSync(buf);
   };
-} else {
-  optional(require);
+
+  brotli.isAvailable = true;
+} else if (optional(require)) {
+  brotli.isAvailable = true;
 }
 
 function optional (require) {
@@ -25,9 +27,9 @@ function optional (require) {
     brotli.decompress = function (buf) {
       return Buffer.from(decompress(buf));
     };
-  } catch (error) {
-    brotli.isAvailable = false;
 
+    return typeof decompress === 'function';
+  } catch (error) {
     // Don't throw an exception if the module is not installed
     if (error.code !== 'MODULE_NOT_FOUND') {
       throw error;


### PR DESCRIPTION
Request doesn't decompress Brotli responses and calls JSON.parse before we have a chance to decompress it. The solution is to parse the response as JSON ourselves whenever the `json` option is truthy, following request's example to match the expected behavior.

I had to adjust `lib/brotli.js` since a test was modifying it's state and causing the new tests to fail.