### PR TITLE
Fix invalid Accept-Encoding

### DIFF
--- a/lib/browsers.json
+++ b/lib/browsers.json
@@ -88,7 +88,7 @@
         "User-Agent": null,
         "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
         "Accept-Language": "en-US,en;q=0.8",
-        "Accept-Encoding": "gzip, deflate, , br"
+        "Accept-Encoding": "gzip, deflate, sdch, br"
       }
     },
     {


### PR DESCRIPTION
Currently, the Accept-Encoding for User Agents <59 is invalid. It's supposed to have a coding after each comma. I changed it to "gzip, deflate, sdch, br" so it matches the Accept-Encoding of Chrome <59.

Perhaps it would be better to remove these old User Agents altogether and add some up-to-date ones. [SDCH was removed in version 59 of Chrome.](https://en.wikipedia.org/wiki/SDCH) It's been well over two years since that version got released and I doubt there are many users running even older versions of Chrome.