### PR TITLE
Fix for error with type for CloudscraperAPI

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-import { Url } from 'url';
+import { URL } from 'url';
 import http = require('http');
 import https = require('https');
 import Promise = require('bluebird');
@@ -20,7 +20,7 @@ declare namespace cloudscraper {
 
     url: string; // <- deprecated
     siteKey: string;
-    uri: Url;
+    uri: URL;
     form: {
       [key: string]: string;
       // Secret form value
@@ -77,7 +77,7 @@ declare namespace cloudscraper {
 
   interface CloudscraperAPI extends request.RequestAPI<Cloudscraper, CoreOptions, request.RequiredUriUrl> {
     defaultParams: DefaultOptions;
-    (options: Options): Promise<string>;
+    (options: OptionsWithUrl): Promise<any>;
   }
 
   type OptionsWithUri = request.UriOptions & CoreOptions;

--- a/index.d.ts
+++ b/index.d.ts
@@ -77,6 +77,7 @@ declare namespace cloudscraper {
 
   interface CloudscraperAPI extends request.RequestAPI<Cloudscraper, CoreOptions, request.RequiredUriUrl> {
     defaultParams: DefaultOptions;
+    (options: Options): Promise<string>;
   }
 
   type OptionsWithUri = request.UriOptions & CoreOptions;


### PR DESCRIPTION
I am running version 4.3.0 with the new TypeScript types and I get an error when running `await cloudscraper(requestOptions);`.

```
TSError: ⨯ Unable to compile TypeScript:
file.ts(221,16): error TS2349: This expression is not callable.
  Type 'CloudscraperAPI' has no call signatures.
```

I have tried to fix it with this pull request. It works on my machine. I was trying to run the tests but they were broken before I made my fix.