### PR TITLE
Fixing 200 HTTP response with empty body

### DIFF
--- a/index.js
+++ b/index.js
@@ -211,7 +211,7 @@ function onRequestResponse (options, error, response, body) {
 function onCloudflareResponse (options, response, body) {
   const callback = options.callback;
 
-  if (body.length < 1) {
+  if (!(response.statusCode >= 200 && response.statusCode < 300) && body.length < 1) {
     // This is a 4xx-5xx Cloudflare response with an empty body.
     return callback(new CloudflareError(response.statusCode, options, response));
   }


### PR DESCRIPTION
I just encountered a case where cloudflare were returning 200 OK, but the code was still throwing an error. Fixed that by checking the length of the body and _also_ the response status code.